### PR TITLE
Fix stupid mistake in our fips202.c

### DIFF
--- a/common/fips202.c
+++ b/common/fips202.c
@@ -157,6 +157,7 @@ static void keccak_inc_finalize(uint64_t *s_inc, uint32_t r, uint8_t p) {
     t[r - 1] |= 128;
 
     KeccakF1600_StateXORBytes(s_inc, t, 0, r);
+    s_inc[25] = 0;
 }
 
 /*************************************************


### PR DESCRIPTION
I've noticed that the incremental shake128 didn't produce the same testvectors as the normal shake128. 
This was due to a mistake I made when porting the incremental API in `fips202.c` to pqm4. 
Since the fips202.c is used for both the host and the m4, this was not caught by the testvectors test. 

It might be worth to compare testvector/nistkat hashes to the ones specified in the `META.yml` from PQClean. This would catch such mistakes in the future. 

