### PR TITLE
Add Round5 opt

### DIFF
--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/LICENSE
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/LICENSE
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/LICENSE

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/api.h
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/api.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/api.h

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/blnk.c
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/blnk.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.c

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/blnk.h
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/blnk.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.h

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/ct_util.c
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/ct_util.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.c

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/ct_util.h
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/ct_util.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.h

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/kem.c
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/kem.c

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/little_endian.h
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/little_endian.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/little_endian.h

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/nist_kem.h
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/nist_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/nist_kem.h

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_addsub.c
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_addsub.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.c

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_addsub.h
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_addsub.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.h

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_cca_kem.c
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_cca_kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.c

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_cca_kem.h
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_cca_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.h

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_cpa_pke.h
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_cpa_pke.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke.h

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_cpa_pke_n1.c
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_cpa_pke_n1.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_n1.c

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_cpa_pke_nd.c
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_cpa_pke_nd.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_nd.c

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_matmul.c
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_matmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.c

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_matmul.h
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_matmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.h

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_parameter_sets.h
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_parameter_sets.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_parameter_sets.h

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_ringmul.c
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_ringmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.c

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_ringmul.h
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_ringmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.h

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_xof.h
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_xof.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof.h

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_xof_shake.c
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_xof_shake.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_shake.c

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_xof_sneik.c
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/r5_xof_sneik.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_sneik.c

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/round5_variant_setting.h
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/round5_variant_setting.h
@@ -1,0 +1,7 @@
+//  round5_variant_setting.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
+#define R5N1_1KEM_0d
+#define ROUND5_CCA_PKE
+#define BLNK2

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/sneik_f512_c99.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_f512_c99.c

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/sneik_param.h
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/sneik_param.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_param.h

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/xe2_c16.c
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/xe2_c16.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe2_c16.c

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/xe4_c64.c
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/xe4_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe4_c64.c

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/xe5_c64.c
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/xe5_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe5_c64.c

--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/xef.h
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/xef.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xef.h

--- a/crypto_kem/r5n1-1kemcca-0d/opt/LICENSE
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/LICENSE
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/LICENSE

--- a/crypto_kem/r5n1-1kemcca-0d/opt/api.h
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/api.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/api.h

--- a/crypto_kem/r5n1-1kemcca-0d/opt/blnk.c
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/blnk.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.c

--- a/crypto_kem/r5n1-1kemcca-0d/opt/blnk.h
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/blnk.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.h

--- a/crypto_kem/r5n1-1kemcca-0d/opt/ct_util.c
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/ct_util.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.c

--- a/crypto_kem/r5n1-1kemcca-0d/opt/ct_util.h
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/ct_util.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.h

--- a/crypto_kem/r5n1-1kemcca-0d/opt/kem.c
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/kem.c

--- a/crypto_kem/r5n1-1kemcca-0d/opt/little_endian.h
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/little_endian.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/little_endian.h

--- a/crypto_kem/r5n1-1kemcca-0d/opt/nist_kem.h
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/nist_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/nist_kem.h

--- a/crypto_kem/r5n1-1kemcca-0d/opt/r5_addsub.c
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/r5_addsub.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.c

--- a/crypto_kem/r5n1-1kemcca-0d/opt/r5_addsub.h
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/r5_addsub.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.h

--- a/crypto_kem/r5n1-1kemcca-0d/opt/r5_cca_kem.c
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/r5_cca_kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.c

--- a/crypto_kem/r5n1-1kemcca-0d/opt/r5_cca_kem.h
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/r5_cca_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.h

--- a/crypto_kem/r5n1-1kemcca-0d/opt/r5_cpa_pke.h
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/r5_cpa_pke.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke.h

--- a/crypto_kem/r5n1-1kemcca-0d/opt/r5_cpa_pke_n1.c
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/r5_cpa_pke_n1.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_n1.c

--- a/crypto_kem/r5n1-1kemcca-0d/opt/r5_cpa_pke_nd.c
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/r5_cpa_pke_nd.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_nd.c

--- a/crypto_kem/r5n1-1kemcca-0d/opt/r5_matmul.c
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/r5_matmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.c

--- a/crypto_kem/r5n1-1kemcca-0d/opt/r5_matmul.h
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/r5_matmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.h

--- a/crypto_kem/r5n1-1kemcca-0d/opt/r5_parameter_sets.h
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/r5_parameter_sets.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_parameter_sets.h

--- a/crypto_kem/r5n1-1kemcca-0d/opt/r5_ringmul.c
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/r5_ringmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.c

--- a/crypto_kem/r5n1-1kemcca-0d/opt/r5_ringmul.h
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/r5_ringmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.h

--- a/crypto_kem/r5n1-1kemcca-0d/opt/r5_xof.h
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/r5_xof.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof.h

--- a/crypto_kem/r5n1-1kemcca-0d/opt/r5_xof_shake.c
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/r5_xof_shake.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_shake.c

--- a/crypto_kem/r5n1-1kemcca-0d/opt/r5_xof_sneik.c
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/r5_xof_sneik.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_sneik.c

--- a/crypto_kem/r5n1-1kemcca-0d/opt/round5_variant_setting.h
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/round5_variant_setting.h
@@ -1,0 +1,7 @@
+//  round5_variant_setting.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
+#define R5N1_1KEM_0d
+#define ROUND5_CCA_PKE
+

--- a/crypto_kem/r5n1-1kemcca-0d/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/sneik_f512_c99.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_f512_c99.c

--- a/crypto_kem/r5n1-1kemcca-0d/opt/sneik_param.h
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/sneik_param.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_param.h

--- a/crypto_kem/r5n1-1kemcca-0d/opt/xe2_c16.c
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/xe2_c16.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe2_c16.c

--- a/crypto_kem/r5n1-1kemcca-0d/opt/xe4_c64.c
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/xe4_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe4_c64.c

--- a/crypto_kem/r5n1-1kemcca-0d/opt/xe5_c64.c
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/xe5_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe5_c64.c

--- a/crypto_kem/r5n1-1kemcca-0d/opt/xef.h
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/xef.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xef.h

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/LICENSE
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/LICENSE
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/LICENSE

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/api.h
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/api.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/api.h

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/blnk.c
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/blnk.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.c

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/blnk.h
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/blnk.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.h

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/ct_util.c
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/ct_util.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.c

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/ct_util.h
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/ct_util.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.h

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/kem.c
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/kem.c

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/little_endian.h
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/little_endian.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/little_endian.h

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/nist_kem.h
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/nist_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/nist_kem.h

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_addsub.c
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_addsub.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.c

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_addsub.h
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_addsub.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.h

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_cca_kem.c
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_cca_kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.c

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_cca_kem.h
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_cca_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.h

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_cpa_pke.h
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_cpa_pke.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke.h

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_cpa_pke_n1.c
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_cpa_pke_n1.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_n1.c

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_cpa_pke_nd.c
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_cpa_pke_nd.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_nd.c

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_matmul.c
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_matmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.c

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_matmul.h
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_matmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.h

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_parameter_sets.h
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_parameter_sets.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_parameter_sets.h

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_ringmul.c
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_ringmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.c

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_ringmul.h
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_ringmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.h

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_xof.h
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_xof.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof.h

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_xof_shake.c
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_xof_shake.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_shake.c

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_xof_sneik.c
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/r5_xof_sneik.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_sneik.c

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/round5_variant_setting.h
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/round5_variant_setting.h
@@ -1,0 +1,8 @@
+//  round5_variant_setting.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
+#define R5N1_3KEM_0d
+#define ROUND5_CCA_PKE
+#define BLNK2
+

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/sneik_f512_c99.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_f512_c99.c

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/sneik_param.h
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/sneik_param.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_param.h

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/xe2_c16.c
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/xe2_c16.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe2_c16.c

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/xe4_c64.c
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/xe4_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe4_c64.c

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/xe5_c64.c
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/xe5_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe5_c64.c

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/xef.h
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/xef.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xef.h

--- a/crypto_kem/r5n1-3kemcca-0d/opt/LICENSE
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/LICENSE
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/LICENSE

--- a/crypto_kem/r5n1-3kemcca-0d/opt/api.h
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/api.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/api.h

--- a/crypto_kem/r5n1-3kemcca-0d/opt/blnk.c
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/blnk.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.c

--- a/crypto_kem/r5n1-3kemcca-0d/opt/blnk.h
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/blnk.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.h

--- a/crypto_kem/r5n1-3kemcca-0d/opt/ct_util.c
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/ct_util.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.c

--- a/crypto_kem/r5n1-3kemcca-0d/opt/ct_util.h
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/ct_util.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.h

--- a/crypto_kem/r5n1-3kemcca-0d/opt/kem.c
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/kem.c

--- a/crypto_kem/r5n1-3kemcca-0d/opt/little_endian.h
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/little_endian.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/little_endian.h

--- a/crypto_kem/r5n1-3kemcca-0d/opt/nist_kem.h
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/nist_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/nist_kem.h

--- a/crypto_kem/r5n1-3kemcca-0d/opt/r5_addsub.c
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/r5_addsub.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.c

--- a/crypto_kem/r5n1-3kemcca-0d/opt/r5_addsub.h
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/r5_addsub.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.h

--- a/crypto_kem/r5n1-3kemcca-0d/opt/r5_cca_kem.c
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/r5_cca_kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.c

--- a/crypto_kem/r5n1-3kemcca-0d/opt/r5_cca_kem.h
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/r5_cca_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.h

--- a/crypto_kem/r5n1-3kemcca-0d/opt/r5_cpa_pke.h
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/r5_cpa_pke.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke.h

--- a/crypto_kem/r5n1-3kemcca-0d/opt/r5_cpa_pke_n1.c
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/r5_cpa_pke_n1.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_n1.c

--- a/crypto_kem/r5n1-3kemcca-0d/opt/r5_cpa_pke_nd.c
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/r5_cpa_pke_nd.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_nd.c

--- a/crypto_kem/r5n1-3kemcca-0d/opt/r5_matmul.c
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/r5_matmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.c

--- a/crypto_kem/r5n1-3kemcca-0d/opt/r5_matmul.h
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/r5_matmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.h

--- a/crypto_kem/r5n1-3kemcca-0d/opt/r5_parameter_sets.h
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/r5_parameter_sets.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_parameter_sets.h

--- a/crypto_kem/r5n1-3kemcca-0d/opt/r5_ringmul.c
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/r5_ringmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.c

--- a/crypto_kem/r5n1-3kemcca-0d/opt/r5_ringmul.h
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/r5_ringmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.h

--- a/crypto_kem/r5n1-3kemcca-0d/opt/r5_xof.h
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/r5_xof.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof.h

--- a/crypto_kem/r5n1-3kemcca-0d/opt/r5_xof_shake.c
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/r5_xof_shake.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_shake.c

--- a/crypto_kem/r5n1-3kemcca-0d/opt/r5_xof_sneik.c
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/r5_xof_sneik.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_sneik.c

--- a/crypto_kem/r5n1-3kemcca-0d/opt/round5_variant_setting.h
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/round5_variant_setting.h
@@ -1,0 +1,7 @@
+//  round5_variant_setting.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
+#define R5N1_3KEM_0d
+#define ROUND5_CCA_PKE
+

--- a/crypto_kem/r5n1-3kemcca-0d/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/sneik_f512_c99.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_f512_c99.c

--- a/crypto_kem/r5n1-3kemcca-0d/opt/sneik_param.h
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/sneik_param.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_param.h

--- a/crypto_kem/r5n1-3kemcca-0d/opt/xe2_c16.c
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/xe2_c16.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe2_c16.c

--- a/crypto_kem/r5n1-3kemcca-0d/opt/xe4_c64.c
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/xe4_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe4_c64.c

--- a/crypto_kem/r5n1-3kemcca-0d/opt/xe5_c64.c
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/xe5_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe5_c64.c

--- a/crypto_kem/r5n1-3kemcca-0d/opt/xef.h
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/xef.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xef.h

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/LICENSE
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/LICENSE
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/LICENSE

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/api.h
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/api.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/api.h

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/blnk.c
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/blnk.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.c

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/blnk.h
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/blnk.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.h

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/ct_util.c
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/ct_util.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.c

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/ct_util.h
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/ct_util.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.h

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/kem.c
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/kem.c

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/little_endian.h
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/little_endian.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/little_endian.h

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/nist_kem.h
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/nist_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/nist_kem.h

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_addsub.c
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_addsub.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.c

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_addsub.h
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_addsub.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.h

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_cca_kem.c
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_cca_kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.c

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_cca_kem.h
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_cca_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.h

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_cpa_pke.h
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_cpa_pke.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke.h

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_cpa_pke_n1.c
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_cpa_pke_n1.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_n1.c

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_cpa_pke_nd.c
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_cpa_pke_nd.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_nd.c

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_matmul.c
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_matmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.c

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_matmul.h
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_matmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.h

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_parameter_sets.h
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_parameter_sets.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_parameter_sets.h

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_ringmul.c
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_ringmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.c

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_ringmul.h
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_ringmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.h

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_xof.h
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_xof.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof.h

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_xof_shake.c
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_xof_shake.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_shake.c

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_xof_sneik.c
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/r5_xof_sneik.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_sneik.c

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/round5_variant_setting.h
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/round5_variant_setting.h
@@ -1,0 +1,7 @@
+//  round5_variant_setting.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
+#define R5N1_5KEM_0d
+#define ROUND5_CCA_PKE
+#define BLNK2

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/sneik_f512_c99.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_f512_c99.c

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/sneik_param.h
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/sneik_param.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_param.h

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/xe2_c16.c
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/xe2_c16.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe2_c16.c

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/xe4_c64.c
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/xe4_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe4_c64.c

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/xe5_c64.c
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/xe5_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe5_c64.c

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/xef.h
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/xef.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xef.h

--- a/crypto_kem/r5n1-5kemcca-0d/opt/LICENSE
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/LICENSE
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/LICENSE

--- a/crypto_kem/r5n1-5kemcca-0d/opt/api.h
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/api.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/api.h

--- a/crypto_kem/r5n1-5kemcca-0d/opt/blnk.c
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/blnk.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.c

--- a/crypto_kem/r5n1-5kemcca-0d/opt/blnk.h
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/blnk.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.h

--- a/crypto_kem/r5n1-5kemcca-0d/opt/ct_util.c
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/ct_util.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.c

--- a/crypto_kem/r5n1-5kemcca-0d/opt/ct_util.h
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/ct_util.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.h

--- a/crypto_kem/r5n1-5kemcca-0d/opt/kem.c
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/kem.c

--- a/crypto_kem/r5n1-5kemcca-0d/opt/little_endian.h
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/little_endian.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/little_endian.h

--- a/crypto_kem/r5n1-5kemcca-0d/opt/nist_kem.h
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/nist_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/nist_kem.h

--- a/crypto_kem/r5n1-5kemcca-0d/opt/r5_addsub.c
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/r5_addsub.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.c

--- a/crypto_kem/r5n1-5kemcca-0d/opt/r5_addsub.h
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/r5_addsub.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.h

--- a/crypto_kem/r5n1-5kemcca-0d/opt/r5_cca_kem.c
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/r5_cca_kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.c

--- a/crypto_kem/r5n1-5kemcca-0d/opt/r5_cca_kem.h
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/r5_cca_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.h

--- a/crypto_kem/r5n1-5kemcca-0d/opt/r5_cpa_pke.h
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/r5_cpa_pke.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke.h

--- a/crypto_kem/r5n1-5kemcca-0d/opt/r5_cpa_pke_n1.c
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/r5_cpa_pke_n1.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_n1.c

--- a/crypto_kem/r5n1-5kemcca-0d/opt/r5_cpa_pke_nd.c
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/r5_cpa_pke_nd.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_nd.c

--- a/crypto_kem/r5n1-5kemcca-0d/opt/r5_matmul.c
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/r5_matmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.c

--- a/crypto_kem/r5n1-5kemcca-0d/opt/r5_matmul.h
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/r5_matmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.h

--- a/crypto_kem/r5n1-5kemcca-0d/opt/r5_parameter_sets.h
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/r5_parameter_sets.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_parameter_sets.h

--- a/crypto_kem/r5n1-5kemcca-0d/opt/r5_ringmul.c
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/r5_ringmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.c

--- a/crypto_kem/r5n1-5kemcca-0d/opt/r5_ringmul.h
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/r5_ringmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.h

--- a/crypto_kem/r5n1-5kemcca-0d/opt/r5_xof.h
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/r5_xof.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof.h

--- a/crypto_kem/r5n1-5kemcca-0d/opt/r5_xof_shake.c
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/r5_xof_shake.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_shake.c

--- a/crypto_kem/r5n1-5kemcca-0d/opt/r5_xof_sneik.c
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/r5_xof_sneik.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_sneik.c

--- a/crypto_kem/r5n1-5kemcca-0d/opt/round5_variant_setting.h
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/round5_variant_setting.h
@@ -1,0 +1,7 @@
+//  round5_variant_setting.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
+#define R5N1_5KEM_0d
+#define ROUND5_CCA_PKE
+

--- a/crypto_kem/r5n1-5kemcca-0d/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/sneik_f512_c99.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_f512_c99.c

--- a/crypto_kem/r5n1-5kemcca-0d/opt/sneik_param.h
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/sneik_param.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_param.h

--- a/crypto_kem/r5n1-5kemcca-0d/opt/xe2_c16.c
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/xe2_c16.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe2_c16.c

--- a/crypto_kem/r5n1-5kemcca-0d/opt/xe4_c64.c
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/xe4_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe4_c64.c

--- a/crypto_kem/r5n1-5kemcca-0d/opt/xe5_c64.c
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/xe5_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe5_c64.c

--- a/crypto_kem/r5n1-5kemcca-0d/opt/xef.h
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/xef.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xef.h

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/LICENSE
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/LICENSE
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/LICENSE

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/api.h
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/api.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/api.h

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/blnk.c
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/blnk.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.c

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/blnk.h
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/blnk.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.h

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/ct_util.c
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/ct_util.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.c

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/ct_util.h
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/ct_util.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.h

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/kem.c
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/kem.c

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/little_endian.h
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/little_endian.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/little_endian.h

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/nist_kem.h
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/nist_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/nist_kem.h

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_addsub.c
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_addsub.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.c

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_addsub.h
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_addsub.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.h

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_cca_kem.c
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_cca_kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.c

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_cca_kem.h
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_cca_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.h

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_cpa_pke.h
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_cpa_pke.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke.h

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_cpa_pke_n1.c
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_cpa_pke_n1.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_n1.c

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_cpa_pke_nd.c
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_cpa_pke_nd.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_nd.c

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_matmul.c
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_matmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.c

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_matmul.h
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_matmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.h

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_parameter_sets.h
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_parameter_sets.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_parameter_sets.h

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_ringmul.c
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_ringmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.c

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_ringmul.h
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_ringmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.h

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_xof.h
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_xof.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof.h

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_xof_shake.c
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_xof_shake.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_shake.c

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_xof_sneik.c
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/r5_xof_sneik.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_sneik.c

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/round5_variant_setting.h
@@ -1,0 +1,7 @@
+//  round5_variant_setting.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
+#define R5ND_1KEM_0d
+#define ROUND5_CCA_PKE
+#define BLNK2

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/sneik_f512_c99.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_f512_c99.c

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/sneik_param.h
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/sneik_param.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_param.h

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/xe2_c16.c
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/xe2_c16.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe2_c16.c

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/xe4_c64.c
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/xe4_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe4_c64.c

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/xe5_c64.c
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/xe5_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe5_c64.c

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/xef.h
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/xef.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xef.h

--- a/crypto_kem/r5nd-1kemcca-0d/opt/LICENSE
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/LICENSE
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/LICENSE

--- a/crypto_kem/r5nd-1kemcca-0d/opt/api.h
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/api.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/api.h

--- a/crypto_kem/r5nd-1kemcca-0d/opt/blnk.c
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/blnk.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.c

--- a/crypto_kem/r5nd-1kemcca-0d/opt/blnk.h
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/blnk.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.h

--- a/crypto_kem/r5nd-1kemcca-0d/opt/ct_util.c
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/ct_util.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.c

--- a/crypto_kem/r5nd-1kemcca-0d/opt/ct_util.h
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/ct_util.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.h

--- a/crypto_kem/r5nd-1kemcca-0d/opt/kem.c
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/kem.c

--- a/crypto_kem/r5nd-1kemcca-0d/opt/little_endian.h
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/little_endian.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/little_endian.h

--- a/crypto_kem/r5nd-1kemcca-0d/opt/nist_kem.h
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/nist_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/nist_kem.h

--- a/crypto_kem/r5nd-1kemcca-0d/opt/r5_addsub.c
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/r5_addsub.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.c

--- a/crypto_kem/r5nd-1kemcca-0d/opt/r5_addsub.h
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/r5_addsub.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.h

--- a/crypto_kem/r5nd-1kemcca-0d/opt/r5_cca_kem.c
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/r5_cca_kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.c

--- a/crypto_kem/r5nd-1kemcca-0d/opt/r5_cca_kem.h
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/r5_cca_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.h

--- a/crypto_kem/r5nd-1kemcca-0d/opt/r5_cpa_pke.h
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/r5_cpa_pke.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke.h

--- a/crypto_kem/r5nd-1kemcca-0d/opt/r5_cpa_pke_n1.c
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/r5_cpa_pke_n1.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_n1.c

--- a/crypto_kem/r5nd-1kemcca-0d/opt/r5_cpa_pke_nd.c
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/r5_cpa_pke_nd.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_nd.c

--- a/crypto_kem/r5nd-1kemcca-0d/opt/r5_matmul.c
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/r5_matmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.c

--- a/crypto_kem/r5nd-1kemcca-0d/opt/r5_matmul.h
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/r5_matmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.h

--- a/crypto_kem/r5nd-1kemcca-0d/opt/r5_parameter_sets.h
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/r5_parameter_sets.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_parameter_sets.h

--- a/crypto_kem/r5nd-1kemcca-0d/opt/r5_ringmul.c
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/r5_ringmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.c

--- a/crypto_kem/r5nd-1kemcca-0d/opt/r5_ringmul.h
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/r5_ringmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.h

--- a/crypto_kem/r5nd-1kemcca-0d/opt/r5_xof.h
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/r5_xof.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof.h

--- a/crypto_kem/r5nd-1kemcca-0d/opt/r5_xof_shake.c
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/r5_xof_shake.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_shake.c

--- a/crypto_kem/r5nd-1kemcca-0d/opt/r5_xof_sneik.c
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/r5_xof_sneik.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_sneik.c

--- a/crypto_kem/r5nd-1kemcca-0d/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/round5_variant_setting.h
@@ -1,0 +1,7 @@
+//  round5_variant_setting.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
+#define R5ND_1KEM_0d
+#define ROUND5_CCA_PKE
+

--- a/crypto_kem/r5nd-1kemcca-0d/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/sneik_f512_c99.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_f512_c99.c

--- a/crypto_kem/r5nd-1kemcca-0d/opt/sneik_param.h
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/sneik_param.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_param.h

--- a/crypto_kem/r5nd-1kemcca-0d/opt/xe2_c16.c
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/xe2_c16.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe2_c16.c

--- a/crypto_kem/r5nd-1kemcca-0d/opt/xe4_c64.c
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/xe4_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe4_c64.c

--- a/crypto_kem/r5nd-1kemcca-0d/opt/xe5_c64.c
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/xe5_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe5_c64.c

--- a/crypto_kem/r5nd-1kemcca-0d/opt/xef.h
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/xef.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xef.h

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/LICENSE
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/LICENSE
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/LICENSE

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/api.h
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/api.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/api.h

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/blnk.c
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/blnk.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.c

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/blnk.h
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/blnk.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.h

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/ct_util.c
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/ct_util.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.c

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/ct_util.h
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/ct_util.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.h

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/kem.c
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/kem.c

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/little_endian.h
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/little_endian.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/little_endian.h

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/nist_kem.h
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/nist_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/nist_kem.h

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_addsub.c
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_addsub.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.c

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_addsub.h
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_addsub.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.h

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_cca_kem.c
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_cca_kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.c

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_cca_kem.h
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_cca_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.h

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_cpa_pke.h
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_cpa_pke.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke.h

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_cpa_pke_n1.c
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_cpa_pke_n1.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_n1.c

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_cpa_pke_nd.c
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_cpa_pke_nd.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_nd.c

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_matmul.c
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_matmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.c

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_matmul.h
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_matmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.h

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_parameter_sets.h
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_parameter_sets.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_parameter_sets.h

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_ringmul.c
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_ringmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.c

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_ringmul.h
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_ringmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.h

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_xof.h
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_xof.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof.h

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_xof_shake.c
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_xof_shake.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_shake.c

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_xof_sneik.c
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/r5_xof_sneik.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_sneik.c

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/round5_variant_setting.h
@@ -1,0 +1,8 @@
+//  round5_variant_setting.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
+#define R5ND_1KEM_5d
+#define ROUND5_CCA_PKE
+#define BLNK2
+

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/sneik_f512_c99.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_f512_c99.c

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/sneik_param.h
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/sneik_param.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_param.h

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/xe2_c16.c
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/xe2_c16.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe2_c16.c

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/xe4_c64.c
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/xe4_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe4_c64.c

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/xe5_c64.c
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/xe5_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe5_c64.c

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/xef.h
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/xef.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xef.h

--- a/crypto_kem/r5nd-1kemcca-5d/opt/LICENSE
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/LICENSE
@@ -32,12 +32,12 @@
  ====================================================
 
  Copyright (C) 2019, PQShield Ltd.
- 
+
  All rights reserved. A copyright license for redistribution and use in
  source and binary forms, with or without modification, is hereby granted for
  non-commercial, experimental, research, public review and evaluation
  purposes, provided that the following conditions are met:
- 
+
  * Redistributions of source code must retain the above copyright notice,
    this list of conditions and the following disclaimer.
 

--- a/crypto_kem/r5nd-1kemcca-5d/opt/LICENSE
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/LICENSE
@@ -1,0 +1,58 @@
+ ROUND5 Software
+ ===============
+
+ Copyright (c) 2018, 2019, Koninklijke Philips N.V. and PQShield Ltd.
+
+ All rights reserved. A copyright license for redistribution and use in
+ source and binary forms, with or without modification, is hereby granted for
+ non-commercial, experimental, research, public review and evaluation
+ purposes, provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+
+
+ SNEIK, SNEIKEN, SNEIKHA, BLNK2, and Related Software
+ ====================================================
+
+ Copyright (C) 2019, PQShield Ltd.
+ 
+ All rights reserved. A copyright license for redistribution and use in
+ source and binary forms, with or without modification, is hereby granted for
+ non-commercial, experimental, research, public review and evaluation
+ purposes, provided that the following conditions are met:
+ 
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.

--- a/crypto_kem/r5nd-1kemcca-5d/opt/api.h
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/api.h
@@ -1,0 +1,13 @@
+//  api.h
+//  Stub api.h interface for testing. Overwritten for distribution.
+
+//  Copyright (c) 2019, PQSHield Ltd.
+
+
+#ifndef _API_H_
+#define _API_H_
+
+#include "r5_parameter_sets.h"
+#include "nist_kem.h"
+
+#endif /* _API_H_ */

--- a/crypto_kem/r5nd-1kemcca-5d/opt/blnk.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/blnk.c
@@ -1,0 +1,165 @@
+//  blnk.c
+//  2019-02-20  Markku-Juhani O. Saarinen <mjos@pqshield.com>
+//  Copyright (C) 2019, PQShield Ltd. Please see LICENSE.
+
+//  The BLNK2 "core" state manipulation functions.
+
+#ifdef BLNK2
+
+#include "blnk.h"
+
+//  Initialize with given rate and number of rounds
+
+void blnk_clr(blnk_t *ctx, size_t rate, uint8_t rounds)
+{
+    size_t i;
+
+    for (i = 0; i < BLNK_BLOCK; i++)
+        ctx->st.u8[i] = 0;
+
+    ctx->pos = 0;
+    ctx->rate = rate;
+    ctx->rounds = rounds;
+}
+
+//  End a data element (compulsory between different domain types)
+
+void blnk_fin(blnk_t *ctx, blnk_dom_t dom)
+{
+    const uint8_t pad[1] = { 0x01 };
+
+    blnk_put(ctx, dom, pad, 1);                         // padding bit
+    if ((dom & BLNK_FULL) == 0) {                       // not full-state ?
+        ctx->st.u8[ctx->rate - 1] ^= 0x80;              // indicate capacity
+    }
+
+    BLNK_PI(&ctx->st, dom | BLNK_LAST, ctx->rounds);    // finalize
+
+    ctx->pos = 0;
+}
+
+//  Absorb data
+
+void blnk_put(blnk_t *ctx, blnk_dom_t dom, const void *in, size_t len)
+{
+    size_t i, j, r;
+
+    i = ctx->pos;
+    r = dom & BLNK_FULL ? BLNK_BLOCK : ctx->rate;       // full-state ?
+
+    for (j = 0; j < len; j++) {
+        if (i >= r) {
+            BLNK_PI(&ctx->st, dom, ctx->rounds);
+            i = 0;
+        }
+        ctx->st.u8[i++] ^= ((const uint8_t *) in)[j];
+    }
+    ctx->pos = i;
+}
+
+//  Squeeze data
+
+void blnk_get(blnk_t *ctx, blnk_dom_t dom, void *out, size_t len)
+{
+    size_t i, j, r;
+
+    i = ctx->pos;
+    r = ctx->rate;
+
+    for (j = 0; j < len; j++) {
+        if (i >= r) {
+            BLNK_PI(&ctx->st, dom, ctx->rounds);
+            i = 0;
+        }
+        ((uint8_t *) out)[j] = ctx->st.u8[i++];
+    }
+
+    ctx->pos = i;
+}
+
+//  Encrypt data
+
+void blnk_enc(blnk_t *ctx, blnk_dom_t dom,
+    void *out, const void *in, size_t len)
+{
+    size_t i, j, r;
+
+    i = ctx->pos;
+    r = ctx->rate;
+
+    for (j = 0; j < len; j++) {
+        if (i >= r) {
+            BLNK_PI(&ctx->st, dom, ctx->rounds);
+            i = 0;
+        }
+        ctx->st.u8[i] ^= ((const uint8_t *) in)[j];
+        ((uint8_t *) out)[j] = ctx->st.u8[i++];
+    }
+
+    ctx->pos = i;
+}
+
+//  Decrypt data
+
+void blnk_dec(blnk_t *ctx, blnk_dom_t dom,
+    void *out, const void *in, size_t len)
+{
+    size_t i, j, r;
+    uint8_t t;
+
+    i = ctx->pos;
+    r = ctx->rate;
+
+    for (j = 0; j < len; j++) {
+        if (i >= r) {
+            BLNK_PI(&ctx->st, dom, ctx->rounds);
+            i = 0;
+        }
+        t = ((const uint8_t *) in)[j];
+        ((uint8_t *) out)[j] = ctx->st.u8[i] ^ t;
+        ctx->st.u8[i++] = t;
+    }
+
+    ctx->pos = i;
+}
+
+//  Compare to output (0 == equal)
+
+int blnk_cmp(blnk_t *ctx, blnk_dom_t dom, const void *in, size_t len)
+{
+    size_t i, j, r;
+    uint8_t t;
+
+    i = ctx->pos;
+    r = ctx->rate;
+    t = 0;
+
+    for (j = 0; j < len; j++) {
+        if (i >= r) {
+            BLNK_PI(&ctx->st, dom, ctx->rounds);
+            i = 0;
+        }
+        t |= ((const uint8_t *) in)[j] ^ ctx->st.u8[i++];
+    }
+
+    ctx->pos = i;
+
+    return t != 0;
+}
+
+//  Ratchet for forward security
+
+void blnk_ratchet(blnk_t *ctx)
+{
+    size_t i, r;
+
+    r = ctx->rate;
+
+    for (i = 0; i < r; i++) {
+        ctx->st.u8[i] = 0;
+    }
+
+    ctx->pos = 0;
+}
+
+#endif /* BLNK2 */

--- a/crypto_kem/r5nd-1kemcca-5d/opt/blnk.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/blnk.c
@@ -4,6 +4,8 @@
 
 //  The BLNK2 "core" state manipulation functions.
 
+#include "round5_variant_setting.h"
+
 #ifdef BLNK2
 
 #include "blnk.h"

--- a/crypto_kem/r5nd-1kemcca-5d/opt/blnk.h
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/blnk.h
@@ -1,0 +1,75 @@
+//  blnk.h
+//  2019-02-23  Markku-Juhani O. Saarinen <mjos@pqshield.com>
+//  Copyright (C) 2019, PQShield Ltd. Please see LICENSE.
+
+//  The BLNK2 "core" state manipulation functions.
+
+#ifdef BLNK2
+
+#ifndef _BLNK_H_
+#define _BLNK_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+//  Get instantiation
+#include "sneik_param.h"
+
+//  Internal errors indicate a line in the code
+#define BLNK_ERR   (-(__LINE__))
+
+//  Padding identifiers
+#define BLNK_LAST   0x01                    // Last (padded) block of domain
+#define BLNK_FULL   0x02                    // Full state input (0: RATE input)
+#define BLNK_A2B    0x04                    // Alice -> Bob
+#define BLNK_B2A    0x08                    // Bob -> Alice
+#define BLNK_AD     0x10                    // Authenticated data (in)
+#define BLNK_ADF    (BLNK_AD | BLNK_FULL)   // Full-state assoc. data (in)
+#define BLNK_KEY    0x20                    // Secret key (in)
+#define BLNK_KEYF   (BLNK_KEY | BLNK_FULL)  // Secret key/nonce block (in)
+#define BLNK_HASH   0x40                    // Hash/Authentication tag (out)
+#define BLNK_PTCT   0x70                    // Plaintext or Ciphertext (in/out)
+#define BLNK_BIT7   0x80                    // Reserved
+
+// Domain indicator
+typedef uint8_t blnk_dom_t;
+
+//  State
+typedef struct {
+    union {
+        uint8_t  u8[BLNK_BLOCK];            // permutation state
+        uint32_t u32[(BLNK_BLOCK + 3) / 4]; // for alignment
+    } st;
+    uint8_t pos, rate;                      // data position and rate
+    uint8_t rounds;                         // number of rounds
+} blnk_t;
+
+//  Initialize with given rate and number of rounds
+void blnk_clr(blnk_t *st, size_t rate, uint8_t rounds);
+
+//  End a data element (compulsory between different types)
+void blnk_fin(blnk_t *st, blnk_dom_t dom);
+
+//  Absorb data
+void blnk_put(blnk_t *st, blnk_dom_t dom, const void *in, size_t len);
+
+//  Squeeze data
+void blnk_get(blnk_t *st, blnk_dom_t dom, void *out, size_t len);
+
+//  Encrypt data
+void blnk_enc(blnk_t *st, blnk_dom_t dom,
+    void *out, const void *in, size_t len);
+
+//  Decrypt data
+void blnk_dec(blnk_t *st, blnk_dom_t dom,
+    void *out, const void *in, size_t len);
+
+//  Compare to output (0 == equal)
+int blnk_cmp(blnk_t *st, blnk_dom_t dom, const void *in, size_t len);
+
+//  Ratchet for forward security
+void blnk_ratchet(blnk_t *ctx);
+
+#endif
+
+#endif /* BLNK2 */

--- a/crypto_kem/r5nd-1kemcca-5d/opt/ct_util.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/ct_util.c
@@ -1,0 +1,35 @@
+//  ct_util.c
+//  Copyright (c) 2018, PQShield Ltd.
+
+#include "ct_util.h"
+
+// constant time comparison; return nonzero if not equal
+
+uint8_t ct_memcmp(const void *a, const void *b, size_t len)
+{
+    const uint8_t *a8 = (const uint8_t *) a;
+    const uint8_t *b8 = (const uint8_t *) b;
+    uint8_t flag = 0;
+    size_t i;
+
+    for (i = 0; i < len; i++) {
+        flag |= a8[i] ^ b8[i];
+    }
+
+    return flag;
+}
+
+// conditional move; overwrite d with a if flag is nonzero
+
+void ct_cmov(void *d, const void * a, uint8_t flag, size_t len)
+{
+    uint8_t *d8 = (uint8_t *) d;
+    const uint8_t *a8 = (const uint8_t *) a;
+    size_t i;
+
+    flag = -((flag | -flag) >> 7);          // 0x00 or 0xFF
+
+    for (i = 0; i < len; i++) {
+        d8[i] ^= flag & (d8[i] ^ a8[i]);
+    }
+}

--- a/crypto_kem/r5nd-1kemcca-5d/opt/ct_util.h
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/ct_util.h
@@ -1,0 +1,18 @@
+//  ct_util.h
+//  Copyright (c) 2019, PQShield Ltd.
+
+//  Constant-time utility functions.
+
+#ifndef _CT_UTIL_H_
+#define _CT_UTIL_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+//  constant time comparison; return nonzero if not equal
+uint8_t ct_memcmp(const void *a, const void *b, size_t len);
+
+//  conditional move; overwrite d with a if flag is nonzero
+void ct_cmov(void *d, const void * a, uint8_t flag, size_t len);
+
+#endif /* _CT_UTIL_H_ */

--- a/crypto_kem/r5nd-1kemcca-5d/opt/kem.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/kem.c
@@ -1,0 +1,23 @@
+//  kem.c
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  Implementation of NIST KEM API
+
+#include "r5_parameter_sets.h"
+#include "nist_kem.h"
+#include "r5_cca_kem.h"
+
+int crypto_kem_keypair(uint8_t *pk, uint8_t *sk)
+{
+    return r5_cca_kem_keygen(pk, sk);
+}
+
+int crypto_kem_enc(uint8_t *ct, uint8_t *k, const uint8_t *pk)
+{
+    return r5_cca_kem_encapsulate(ct, k, pk);
+}
+
+int crypto_kem_dec(uint8_t *k, const uint8_t *ct, const uint8_t *sk)
+{
+    return r5_cca_kem_decapsulate(k, ct, sk);
+}

--- a/crypto_kem/r5nd-1kemcca-5d/opt/little_endian.h
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/little_endian.h
@@ -1,0 +1,63 @@
+//  little_endian.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+#ifndef _LITTLE_ENDIAN_H_
+#define _LITTLE_ENDIAN_H_
+
+#include <stdint.h>
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define LITTLE_ENDIAN64(x) (x)
+#else
+#define LITTLE_ENDIAN64(x) (             \
+    (((x) & 0xFF00000000000000) >> 56) | \
+    (((x) & 0x00FF000000000000) >> 40) | \
+    (((x) & 0x0000FF0000000000) >> 24) | \
+    (((x) & 0x000000FF00000000) >> 8)  | \
+    (((x) & 0x00000000FF000000) << 8)  | \
+    (((x) & 0x0000000000FF0000) << 24) | \
+    (((x) & 0x000000000000FF00) << 40) | \
+    (((x) & 0x00000000000000FF) << 56)   \
+)
+#endif
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define LITTLE_ENDIAN32(x) (x)
+#else
+#define LITTLE_ENDIAN32(x) (     \
+    (((x) & 0xFF000000) >> 24) | \
+    (((x) & 0x00FF0000) >> 8)  | \
+    (((x) & 0x0000FF00) << 8)  | \
+    (((x) & 0x000000FF) << 24) \
+)
+#endif
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define LITTLE_ENDIAN16(x) (x)
+#else
+#define LITTLE_ENDIAN16(x) ( \
+    (((x) & 0xFF00) >> 8) |  \
+    (((x) & 0x00FF) << 8)    \
+)
+#endif
+
+// can handle non-aligned data
+
+#define GETU32_LE(v) \
+    (((uint32_t) (v)[0])        ^   (((uint32_t) (v)[1]) <<  8) ^ \
+    (((uint32_t) (v)[2]) << 16) ^   (((uint32_t) (v)[3]) << 24))
+
+#define PUTU32_LE(v, x) { \
+    (v)[0] = (uint8_t)  (x);        (v)[1] = (uint8_t) ((x) >>  8); \
+    (v)[2] = (uint8_t) ((x) >> 16); (v)[3] = (uint8_t) ((x) >> 24); }
+
+#define GETU32_BE(v) \
+    (((uint32_t)(v)[0] << 24)   ^   ((uint32_t)(v)[1] << 16) ^ \
+     ((uint32_t)(v)[2] <<  8)   ^   ((uint32_t)(v)[3]))
+
+#define PUTU32_BE(v, x) {\
+    (v)[0] = (uint8_t)((x) >> 24);  (v)[1] = (uint8_t)((x) >> 16); \
+    (v)[2] = (uint8_t)((x) >>  8);  (v)[3] = (uint8_t)(x);  }
+
+
+#endif /* _LITTLE_ENDIAN_H_ */

--- a/crypto_kem/r5nd-1kemcca-5d/opt/nist_kem.h
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/nist_kem.h
@@ -1,0 +1,17 @@
+//  nist_kem.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  The NIST API for KEM (Key Encapsulation Mechanism)
+
+#ifndef _NIST_KEM_H_
+#define _NIST_KEM_H_
+
+int crypto_kem_keypair(unsigned char *pk, unsigned char *sk);
+
+int crypto_kem_enc(unsigned char *ct,
+    unsigned char *k, const unsigned char *pk);
+
+int crypto_kem_dec(unsigned char *k,
+    const unsigned char *ct, const unsigned char *sk);
+
+#endif /* _NIST_KEM_H_ */

--- a/crypto_kem/r5nd-1kemcca-5d/opt/r5_addsub.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/r5_addsub.c
@@ -1,0 +1,75 @@
+//  r5_addsub.c
+//  Copyright (c) 2019, PQShield Ltd.
+
+//  Addition-subtraction loops. The right number of of combined elements
+//  depends on the register file structure of the target -- ARM allows
+//  basically any register to be used as a pointer, which is a benefit.
+
+#include "r5_parameter_sets.h"
+#include "r5_addsub.h"
+
+//  Basic generic C versions
+
+void r5_modq_addsub_d(modq_t *dst,
+    const modq_t *p_add, const modq_t *p_sub)
+{
+    size_t i;
+
+    for (i = 0; i < PARAMS_D; i++) {
+        dst[i] += p_add[i] - p_sub[i];
+    }
+}
+
+void r5_modq_addsub3_d(modq_t *dst,
+    const modq_t *p_add1, const modq_t *p_sub1,
+    const modq_t *p_add2, const modq_t *p_sub2,
+    const modq_t *p_add3, const modq_t *p_sub3)
+{
+    size_t i;
+
+    for (i = 0; i < PARAMS_D; i++) {
+        dst[i] += p_add1[i] - p_sub1[i]
+                + p_add2[i] - p_sub2[i]
+                + p_add3[i] - p_sub3[i];
+    }
+}
+
+void r5_modq_addsub_perm_nbar_d(modq_t *dst, const uint16_t *perm,
+    const modq_t *p_add, const modq_t *p_sub)
+{
+    size_t i, j, k;
+
+    i = 0;
+    for (j = 0; j < PARAMS_D; j++) {
+        k = perm[j];
+        dst[i] += p_add[k] - p_sub[k];
+        i += PARAMS_N_BAR;
+    }
+}
+
+void r5_modq_addsub3_perm_nbar_d(modq_t *dst, const uint16_t *perm,
+    const modq_t *p_add1, const modq_t *p_sub1,
+    const modq_t *p_add2, const modq_t *p_sub2,
+    const modq_t *p_add3, const modq_t *p_sub3)
+{
+    size_t i, j, k;
+
+    i = 0;
+    for (j = 0; j < PARAMS_D; j++) {
+        k = perm[j];
+        dst[i] += p_add1[k] - p_sub1[k]
+                + p_add2[k] - p_sub2[k]
+                + p_add3[k] - p_sub3[k];
+        i += PARAMS_N_BAR;
+    }
+}
+
+void r5_modp_addsub_mu(modp_t *dst,
+    const modp_t *p_add, const modp_t *p_sub)
+{
+    size_t i;
+
+    for (i = 0; i < PARAMS_MU; i++) {
+        dst[i] += p_add[i] - p_sub[i];
+    }
+}

--- a/crypto_kem/r5nd-1kemcca-5d/opt/r5_addsub.h
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/r5_addsub.h
@@ -1,0 +1,34 @@
+//  r5_addsub.h
+//  2019-03-10  Markku-Juhani O. Saarinen <mjos@pqshield.com>
+//  Low-level functions for handling ternary vectors.
+
+//  Copyright (c) 2019, PQShield Ltd.
+
+#ifndef _R5_ADDSUB_H_
+#define _R5_ADDSUB_H_
+
+#include "r5_parameter_sets.h"
+
+//  generic versions
+
+void r5_modq_addsub_d(modq_t *dst,
+    const modq_t *p_add, const modq_t *p_sub);
+
+void r5_modq_addsub3_d(modq_t *dst,
+    const modq_t *p_add1, const modq_t *p_sub1,
+    const modq_t *p_add2, const modq_t *p_sub2,
+    const modq_t *p_add3, const modq_t *p_sub3);
+
+void r5_modq_addsub_perm_nbar_d(modq_t *dst, const uint16_t *perm,
+    const modq_t *p_add, const modq_t *p_sub);
+
+void r5_modq_addsub3_perm_nbar_d(modq_t *dst, const uint16_t *perm,
+    const modq_t *p_add1, const modq_t *p_sub1,
+    const modq_t *p_add2, const modq_t *p_sub2,
+    const modq_t *p_add3, const modq_t *p_sub3);
+
+void r5_modp_addsub_mu(modp_t *dst,
+    const modp_t *p_add, const modp_t *p_sub);
+
+#endif /* _R5_ADDSUB_H_ */
+

--- a/crypto_kem/r5nd-1kemcca-5d/opt/r5_cca_kem.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/r5_cca_kem.c
@@ -1,0 +1,110 @@
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+//  Markku-Juhani O. Saarinen, Koninklijke Philips N.V.
+
+#include "r5_parameter_sets.h"
+
+#ifdef ROUND5_CCA_PKE
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "r5_cca_kem.h"
+#include "r5_cpa_pke.h"
+#include "randombytes.h"
+#include "r5_xof.h"
+#include "ct_util.h"
+
+// CCA-KEM KeyGen()
+
+int r5_cca_kem_keygen(uint8_t *pk, uint8_t *sk)
+{
+    uint8_t y[PARAMS_KAPPA_BYTES];
+
+    /* Generate the base key pair */
+    r5_cpa_pke_keygen(pk, sk);
+
+    /* Append y and pk to sk */
+    randombytes(y, PARAMS_KAPPA_BYTES);
+    memcpy(sk + PARAMS_KAPPA_BYTES, y, PARAMS_KAPPA_BYTES);
+    memcpy(sk + PARAMS_KAPPA_BYTES + PARAMS_KAPPA_BYTES, pk, PARAMS_PK_SIZE);
+
+    return 0;
+}
+
+// CCA-KEM Encaps()
+
+int r5_cca_kem_encapsulate(uint8_t *ct, uint8_t *k, const uint8_t *pk)
+{
+    uint8_t hash_in[PARAMS_KAPPA_BYTES +
+        (PARAMS_CT_SIZE + PARAMS_KAPPA_BYTES > PARAMS_PK_SIZE ?
+            PARAMS_CT_SIZE + PARAMS_KAPPA_BYTES : PARAMS_PK_SIZE)];
+    uint8_t m[PARAMS_KAPPA_BYTES];
+    uint8_t L_g_rho[3][PARAMS_KAPPA_BYTES];
+
+    randombytes(m, PARAMS_KAPPA_BYTES); // generate random m
+
+    memcpy(hash_in, m, PARAMS_KAPPA_BYTES); // G: (l | g | rho) = h(m | pk);
+    memcpy(hash_in + PARAMS_KAPPA_BYTES, pk, PARAMS_PK_SIZE);
+    r5_hash(L_g_rho, 3 * PARAMS_KAPPA_BYTES, hash_in,
+        PARAMS_KAPPA_BYTES + PARAMS_PK_SIZE);
+
+    /* Encrypt  */
+    r5_cpa_pke_encrypt(ct, pk, m, L_g_rho[2]); // m: ct = (U,v)
+
+    /* Append g: ct = (U,v,g) */
+    memcpy(ct + PARAMS_CT_SIZE, L_g_rho[1], PARAMS_KAPPA_BYTES);
+
+    /* k = H(L, ct) */
+    memcpy(hash_in, L_g_rho[0], PARAMS_KAPPA_BYTES);
+    memcpy(hash_in + PARAMS_KAPPA_BYTES,
+            ct, PARAMS_CT_SIZE + PARAMS_KAPPA_BYTES);
+    r5_hash(k, PARAMS_KAPPA_BYTES, hash_in,
+        PARAMS_KAPPA_BYTES + PARAMS_CT_SIZE + PARAMS_KAPPA_BYTES);
+
+    return 0;
+}
+
+// CCA-KEM Decaps()
+
+int r5_cca_kem_decapsulate(uint8_t *k, const uint8_t *ct, const uint8_t *sk)
+{
+    uint8_t hash_in[PARAMS_KAPPA_BYTES + (PARAMS_CT_SIZE + PARAMS_KAPPA_BYTES > PARAMS_PK_SIZE ? PARAMS_CT_SIZE + PARAMS_KAPPA_BYTES : PARAMS_PK_SIZE)];
+    uint8_t m_prime[PARAMS_KAPPA_BYTES];
+    uint8_t L_g_rho_prime[3][PARAMS_KAPPA_BYTES];
+    uint8_t ct_prime[PARAMS_CT_SIZE + PARAMS_KAPPA_BYTES];
+    uint8_t fail;
+
+    r5_cpa_pke_decrypt(m_prime, sk, ct); // r5_cpa_pke_decrypt m'
+
+    memcpy(hash_in, m_prime, PARAMS_KAPPA_BYTES);
+    memcpy(hash_in + PARAMS_KAPPA_BYTES, // (L | g | rho) = h(m | pk)
+            sk + PARAMS_KAPPA_BYTES + PARAMS_KAPPA_BYTES, PARAMS_PK_SIZE);
+    r5_hash(L_g_rho_prime, 3 * PARAMS_KAPPA_BYTES, hash_in,
+        PARAMS_KAPPA_BYTES + PARAMS_PK_SIZE);
+
+    // Encrypt m: ct' = (U',v')
+    r5_cpa_pke_encrypt(ct_prime, sk + PARAMS_KAPPA_BYTES + PARAMS_KAPPA_BYTES,
+        m_prime, L_g_rho_prime[2]);
+
+    // ct' = (U',v',g')
+    memcpy(ct_prime + PARAMS_CT_SIZE, L_g_rho_prime[1], PARAMS_KAPPA_BYTES);
+
+    // k = H(L', ct')
+    memcpy(hash_in, L_g_rho_prime[0], PARAMS_KAPPA_BYTES);
+    // verification ok ?
+    fail = ct_memcmp(ct, ct_prime,
+        PARAMS_CT_SIZE + PARAMS_KAPPA_BYTES);
+
+    // k = H(y, ct') depending on fail state
+    ct_cmov(hash_in, sk + PARAMS_KAPPA_BYTES, PARAMS_KAPPA_BYTES, fail);
+
+    memcpy(hash_in + PARAMS_KAPPA_BYTES, ct_prime,
+        PARAMS_CT_SIZE + PARAMS_KAPPA_BYTES);
+    r5_hash(k, PARAMS_KAPPA_BYTES, hash_in,
+        PARAMS_KAPPA_BYTES + PARAMS_CT_SIZE + PARAMS_KAPPA_BYTES);
+
+    return 0;
+}
+
+#endif /* ROUND5_CCA_PKE */
+

--- a/crypto_kem/r5nd-1kemcca-5d/opt/r5_cca_kem.h
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/r5_cca_kem.h
@@ -1,0 +1,18 @@
+//  r5_cca_kem.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+#ifndef _R5_CCA_KEM_H_
+#define _R5_CCA_KEM_H_
+
+#include <stdint.h>
+
+//  CCA KEM key generation
+int r5_cca_kem_keygen(uint8_t *pk, uint8_t *sk);
+
+//  CCA KEM encapsulate
+int r5_cca_kem_encapsulate(uint8_t *ct, uint8_t *k, const uint8_t *pk);
+
+//  CCA KEM ecapsulate
+int r5_cca_kem_decapsulate(uint8_t *k, const uint8_t *ct, const uint8_t *sk);
+
+#endif /* _R5_CCA_KEM_H_ */

--- a/crypto_kem/r5nd-1kemcca-5d/opt/r5_cpa_pke.h
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/r5_cpa_pke.h
@@ -1,0 +1,19 @@
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+//  Markku-Juhani O. Saarinen, Koninklijke Philips N.V.
+
+#ifndef _R5_CPA_PKE_H_
+#define _R5_CPA_PKE_H_
+
+#include <stdint.h>
+
+//  CPA PKE key generation
+int r5_cpa_pke_keygen(uint8_t *pk, uint8_t *sk);
+
+//  CPA encrypt
+int r5_cpa_pke_encrypt(uint8_t *ct, const uint8_t *pk,
+    const uint8_t *m, const uint8_t *rho);
+
+//  CPA decrypt
+int r5_cpa_pke_decrypt(uint8_t *m, const uint8_t *sk, const uint8_t *ct);
+
+#endif /* _R5_CPA_PKE_H_ */

--- a/crypto_kem/r5nd-1kemcca-5d/opt/r5_cpa_pke_n1.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/r5_cpa_pke_n1.c
@@ -1,0 +1,326 @@
+//  r5_cpa_pke_n1.c
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+#include "r5_parameter_sets.h"
+
+#if (PARAMS_N == 1)
+
+#include <string.h>
+
+#include "r5_cpa_pke.h"
+#include "r5_matmul.h"
+#include "r5_xof.h"
+#include "randombytes.h"
+#include "xef.h"
+#include "little_endian.h"
+
+// create a sparse ternary vector from a seed
+
+static void r5_create_secret_matrix(uint16_t rs_t[][PARAMS_H / 2][2],
+    const uint8_t seed[PARAMS_KAPPA_BYTES])
+{
+    size_t i, l;
+    uint16_t x;
+    uint8_t v[PARAMS_D];
+
+    r5_xof_ctx_t ctx;
+
+    r5_xof_input(&ctx, seed, PARAMS_KAPPA_BYTES);
+
+    // assume PARAMS_N == PARAMS_M
+    for (l = 0; l < PARAMS_N_BAR; l++) {
+
+        memset(v, 0, sizeof(v));        // reset table
+        for (i = 0; i < PARAMS_H; i++) {
+            do {
+                do {
+                    r5_xof_squeeze(&ctx, &x, sizeof (x));
+                    x = LITTLE_ENDIAN16(x);
+                } while (x >= PARAMS_RS_LIM);
+                x /= PARAMS_RS_DIV;
+            } while (v[x]);
+            v[x] = 1;
+            rs_t[l][i >> 1][i & 1] = x; // addition / subtract index
+        }
+    }
+}
+
+//  create "matrix row" a_random
+
+static void r5_matrow_a_random(modq_t *a_random,
+    const uint8_t seed[PARAMS_KAPPA_BYTES])
+{
+    r5_xof(a_random, PARAM_TAU2_A_RANDOM * sizeof(modq_t),
+        seed, PARAMS_KAPPA_BYTES);
+
+#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+    size_t i;
+
+    for (i = 0; i < PARAM_TAU2_A_RANDOM; i++) {
+        a_random[i] = LITTLE_ENDIAN16(a_random[i]);
+    }
+#endif
+}
+
+//  Get q indexes
+
+static int r5_create_a_perm(uint16_t a_perm[PARAMS_D],
+    const uint8_t sigma[PARAMS_KAPPA_BYTES])
+{
+    size_t i;
+    uint16_t rnd;
+    uint8_t v[BITS_TO_BYTES(PARAM_TAU2_A_RANDOM)];      // low ram; use bits
+    r5_xof_ctx_t ctx;
+
+    //  The DRBG customization when creating the tau=1 or tau=2 permutations.
+    static const uint8_t permutation_customization[2] = {0, 1};
+
+    memset(v, 0, sizeof(v));
+
+    r5_xof_s_input(&ctx, sigma, PARAMS_KAPPA_BYTES,
+        permutation_customization, sizeof(permutation_customization));
+
+    for (i = 0; i < PARAMS_D; ++i) {
+        do {
+            r5_xof_squeeze(&ctx, &rnd, sizeof(rnd));
+            rnd = (uint16_t) LITTLE_ENDIAN16(rnd);
+            rnd &= (PARAM_TAU2_A_RANDOM - 1);
+        } while ((v[rnd >> 3] >> (rnd & 7)) & 1);
+        v[rnd >> 3] |= 1 << (rnd & 7);      // set bit
+        a_perm[i] = rnd;
+    }
+
+    return 0;
+}
+
+// compress elements of q bits into p bits and pack into a byte string
+
+static void r5_pack_q_p_round(uint8_t *pv, const modq_t *vq, size_t len,
+    const modq_t rounding_constant)
+{
+#if (PARAMS_P_BITS == 8)
+    size_t i;
+
+    for (i = 0; i < len; i++) {
+        pv[i] = ((vq[i] + rounding_constant) >>
+            (PARAMS_Q_BITS - PARAMS_P_BITS)) & (PARAMS_P - 1);
+    }
+#else
+    size_t i, j;
+    modp_t t;
+
+    memset(pv, 0, (size_t) BITS_TO_BYTES(PARAMS_P_BITS * len));
+    j = 0;
+    for (i = 0; i < len; i++) {
+        t = ((vq[i] + rounding_constant) >>
+            (PARAMS_Q_BITS - PARAMS_P_BITS)) & (PARAMS_P - 1);
+        //pack p bits
+        pv[j >> 3] |= (uint8_t) (t << (j & 7));
+        if ((j & 7) + PARAMS_P_BITS > 8) {
+            pv[(j >> 3) + 1] |= (uint8_t) (t >> (8 - (j & 7)));
+            if ((j & 7) + PARAMS_P_BITS > 16) {
+                pv[(j >> 3) + 2] |= (uint8_t) (t >> (16 - (j & 7)));
+            }
+        }
+        j += PARAMS_P_BITS;
+    }
+#endif
+}
+
+// unpack a byte string into D*M_BAR elements of p bits
+
+static void r5_unpack_p(modp_t *vp, size_t len, const uint8_t *pv)
+{
+#if (PARAMS_P_BITS == 8)
+    memcpy(vp, pv, len);
+#else
+    size_t i, bits_done, idx, bit_idx;
+    modp_t val;
+
+    bits_done = 0;
+    for (i = 0; i < len; i++) {
+        idx = bits_done >> 3;
+        bit_idx = bits_done & 7;
+        val = (uint16_t) (pv[idx] >> bit_idx);
+        if (bit_idx + PARAMS_P_BITS > 8) {
+            /* Get spill over from next packed byte */
+            val = (uint16_t) (val | (pv[idx + 1] << (8 - bit_idx)));
+            if (bit_idx + PARAMS_P_BITS > 16) {
+                /* Get spill over from next packed byte */
+                val = (uint16_t) (val | (pv[idx + 2] << (16 - bit_idx)));
+            }
+        }
+        vp[i] = val & (PARAMS_P - 1);
+        bits_done += PARAMS_P_BITS;
+    }
+#endif
+}
+
+// generate a keypair (sigma, B)
+
+int r5_cpa_pke_keygen(uint8_t *pk, uint8_t *sk)
+{
+    modq_t b[PARAMS_D][PARAMS_N_BAR];
+    uint16_t s_t[PARAMS_N_BAR][PARAMS_H / 2][2];
+
+    modq_t a_random[PARAM_TAU2_A_RANDOM + PARAMS_D];
+    uint16_t a_perm[PARAMS_D];
+
+    // sigma = seed of (permutation of) A
+    randombytes(pk, PARAMS_KAPPA_BYTES);
+
+    // A from sigma
+    r5_matrow_a_random(a_random, pk);
+    memcpy(a_random + PARAM_TAU2_A_RANDOM, a_random, PARAMS_D * sizeof(modq_t));
+
+    // Permutation of a_random
+    r5_create_a_perm(a_perm, pk);
+
+    randombytes(sk, PARAMS_KAPPA_BYTES); // secret key -- Random S
+    r5_create_secret_matrix(s_t, sk);
+
+    r5_matmul_as_q(b, a_random, a_perm, s_t); // B = A * S
+
+    // Compress B q_bits -> p_bits, pk = sigma | B
+    r5_pack_q_p_round(pk + PARAMS_KAPPA_BYTES, &b[0][0],
+        PARAMS_D * PARAMS_N_BAR, PARAMS_H1);
+
+    return 0;
+}
+
+//  foundation encryption function
+
+int r5_cpa_pke_encrypt(uint8_t *ct, const uint8_t *pk, const uint8_t *m,
+    const uint8_t *rho)
+{
+    size_t i, j;
+    uint16_t r_t[PARAMS_M_BAR][PARAMS_H / 2][2];
+    uint16_t a_perm[PARAMS_D];
+    modq_t a_random[PARAM_TAU2_A_RANDOM + PARAMS_D];
+    union {
+        modq_t u_t[PARAMS_M_BAR][PARAMS_D];
+        modp_t b[PARAMS_D][PARAMS_N_BAR];
+    } mat;
+    modp_t x[PARAMS_MU];
+    uint8_t m1[BITS_TO_BYTES(PARAMS_MU * PARAMS_B_BITS)];
+    modp_t t, tm;
+
+    //  Create R
+    r5_create_secret_matrix(r_t, rho);
+
+    //  unpack public key
+    r5_unpack_p(&mat.b[0][0], PARAMS_D * PARAMS_N_BAR, pk + PARAMS_KAPPA_BYTES);
+
+    r5_matmul_rb_p(x, mat.b, r_t); // X = R^T x B    (mod p)
+
+    //  A from sigma
+    r5_matrow_a_random(a_random, pk);
+    memcpy(a_random + PARAM_TAU2_A_RANDOM, a_random,
+        PARAMS_D * sizeof(modq_t));
+
+    //  Permutation of a_random
+    r5_create_a_perm(a_perm, pk);
+
+    r5_matmul_ra_q(mat.u_t, a_random, a_perm, r_t); // U^T = (R^T x A)^T (mod q)
+
+    r5_pack_q_p_round(ct, &mat.u_t[0][0],
+        PARAMS_M_BAR * PARAMS_D, PARAMS_H2);    // ct = U^T | v
+
+    memset(ct + PARAMS_DPU_SIZE, 0, PARAMS_MUT_SIZE);
+
+    //  create the message
+    memcpy(m1, m, PARAMS_KAPPA_BYTES);
+    memset(m1 + PARAMS_KAPPA_BYTES, 0,
+        BITS_TO_BYTES(PARAMS_MU * PARAMS_B_BITS) - PARAMS_KAPPA_BYTES);
+#if (PARAMS_XE != 0)
+    xef_compute(m1, PARAMS_KAPPA_BYTES, PARAMS_F);
+#endif
+
+    j = 8 * PARAMS_DPU_SIZE;
+    for (i = 0; i < PARAMS_MU; i++) { // compute, pack v
+
+        // compress p->t
+        t = ((x[i] + PARAMS_H2) >> (PARAMS_P_BITS - PARAMS_T_BITS));
+
+        // add message
+        tm = (m1[(i * PARAMS_B_BITS) >> 3] >> ((i * PARAMS_B_BITS) & 7));
+#if (8 % PARAMS_B_BITS != 0)
+        if (((i * PARAMS_B_BITS) & 7) + PARAMS_B_BITS > 8) {
+            /* Get spill over from next message byte */
+            tm = (tm | (m1[((i * PARAMS_B_BITS) >> 3) + 1] <<
+                (8 - ((i * PARAMS_B_BITS) & 7))));
+        }
+#endif
+        t = (t + ((tm & ((1 << PARAMS_B_BITS) - 1)) <<
+            (PARAMS_T_BITS - PARAMS_B_BITS))) & ((1 << PARAMS_T_BITS) - 1);
+
+        ct[j >> 3] |= (uint8_t) (t << (j & 7)); // pack t bits
+        if ((j & 7) + PARAMS_T_BITS > 8) {
+            ct[(j >> 3) + 1] |= (uint8_t) (t >> (8 - (j & 7)));
+            if ((j & 7) + PARAMS_T_BITS > 16) {
+                ct[(j >> 3) + 2] |= (uint8_t) (t >> (16 - (j & 7)));
+            }
+        }
+        j += PARAMS_T_BITS;
+    }
+
+    return 0;
+}
+
+int r5_cpa_pke_decrypt(uint8_t *m, const uint8_t *sk, const uint8_t *ct)
+{
+    size_t i, j;
+    uint16_t s_t[PARAMS_N_BAR][PARAMS_H / 2][2];
+
+    modp_t u_t[PARAMS_M_BAR][PARAMS_D];
+    modp_t xp[PARAMS_MU];
+    uint8_t m1[BITS_TO_BYTES(PARAMS_MU * PARAMS_B_BITS)];
+    modp_t t;
+
+    r5_create_secret_matrix(s_t, sk);
+
+    r5_unpack_p((modp_t *) u_t, PARAMS_M_BAR *   PARAMS_D, ct);  // ct = U^T | v
+
+    //  X' = S^T * U (mod p)
+    r5_matmul_us_p(xp, u_t, s_t);
+
+    memset(m1, 0, sizeof(m1));
+
+    j = 8 * PARAMS_DPU_SIZE;
+    for (i = 0; i < PARAMS_MU; i++) {
+        t = (modp_t) (ct[j >> 3] >> (j & 7));               // unpack t bits
+        if ((j & 7) + PARAMS_T_BITS > 8) {
+            t |= (modp_t) (ct[(j >> 3) + 1] << (8 - (j & 7)));
+            if ((j & 7) + PARAMS_T_BITS > 16) {
+                t |= (modp_t) ((ct[(j >> 3) + 2]) << (16 - (j & 7)));
+            }
+        }
+        t &= ((1 << PARAMS_T_BITS) - 1);                    // "v"
+        j += PARAMS_T_BITS;
+
+        //  X' = v - X', compressed to 1 bit
+        t = (t << (PARAMS_P_BITS - PARAMS_T_BITS)) - xp[i];
+        t = ((t + PARAMS_H3) >> (PARAMS_P_BITS - PARAMS_B_BITS))
+            & ((1 << PARAMS_B_BITS) - 1);
+        m1[(i * PARAMS_B_BITS) >> 3] |= t << ((i * PARAMS_B_BITS) & 7);
+#if (8 % PARAMS_B_BITS != 0)
+        if (((i * PARAMS_B_BITS) & 7) + PARAMS_B_BITS > 8) {
+            /* Spill over to next message byte */
+            m1[(i * PARAMS_B_BITS >> 3) + 1] |=
+                    (t >> (8 - ((i * PARAMS_B_BITS) & 7)));
+        }
+#endif
+    }
+
+#if (PARAMS_XE != 0)
+    //  Apply error correction
+    xef_compute(m1, PARAMS_KAPPA_BYTES, PARAMS_F);
+    xef_fixerr(m1, PARAMS_KAPPA_BYTES, PARAMS_F);
+#endif
+    memcpy(m, m1, PARAMS_KAPPA_BYTES);
+
+    return 0;
+}
+
+#endif
+

--- a/crypto_kem/r5nd-1kemcca-5d/opt/r5_cpa_pke_nd.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/r5_cpa_pke_nd.c
@@ -1,0 +1,256 @@
+//  r5_cpa_pke_nd.c
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+#include "r5_parameter_sets.h"
+
+#if (PARAMS_N == PARAMS_D)
+
+#include <string.h>
+
+#include "little_endian.h"
+#include "r5_cpa_pke.h"
+#include "r5_ringmul.h"
+#include "r5_xof.h"
+#include "randombytes.h"
+#include "xef.h"
+
+// create a sparse ternary vector from a seed
+
+static void r5_create_secret_vec(uint16_t idx[PARAMS_H / 2][2],
+    const uint8_t seed[PARAMS_KAPPA_BYTES])
+{
+    size_t i;
+    uint16_t x;
+    uint8_t v[PARAMS_D];
+    r5_xof_ctx_t ctx;
+
+    memset(v, 0, sizeof (v));
+
+    r5_xof_input(&ctx, seed, PARAMS_KAPPA_BYTES);
+
+    for (i = 0; i < PARAMS_H; i++) {
+        do {
+            do {
+                r5_xof_squeeze(&ctx, &x, sizeof(x));
+                x = LITTLE_ENDIAN16(x);
+            } while (x >= PARAMS_RS_LIM);
+            x /= PARAMS_RS_DIV;
+        } while (v[x]);
+        v[x] = 1;
+        idx[i >> 1][i & 1] = x;
+    }
+}
+
+//  master random
+
+static void r5_ring_a_random(modq_t *a_random,
+    const uint8_t seed[PARAMS_KAPPA_BYTES])
+{
+    r5_xof(a_random, PARAMS_D * sizeof (modq_t), seed, PARAMS_KAPPA_BYTES);
+#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+    size_t i;
+
+    for (i = 0; i < PARAMS_D; i++) {
+        a_random[i] = LITTLE_ENDIAN16(a_random[i]);
+    }
+#endif
+}
+
+// compress ND elements of q bits into p bits and pack into a byte string
+
+static void r5_pack_q_p(uint8_t *pv, const modq_t *vq,
+    const modq_t rounding_constant)
+{
+#if (PARAMS_P_BITS == 8)
+    size_t i;
+
+    for (i = 0; i < PARAMS_D; i++) {
+        pv[i] = (uint8_t) (((vq[i] + rounding_constant) >>
+            (PARAMS_Q_BITS - PARAMS_P_BITS)) & (PARAMS_P - 1));
+    }
+#else
+    size_t i, j;
+    modp_t t;
+
+    memset(pv, 0, PARAMS_NDP_SIZE);
+    j = 0;
+    for (i = 0; i < PARAMS_D; i++) {
+        t = ((vq[i] + rounding_constant) >>
+                (PARAMS_Q_BITS - PARAMS_P_BITS)) & (PARAMS_P - 1);
+        pv[j >> 3] = (uint8_t) (pv[j >> 3] | (t << (j & 7))); // pack p bits
+        if ((j & 7) + PARAMS_P_BITS > 8) {
+            pv[(j >> 3) + 1] =
+                (uint8_t) (pv[(j >> 3) + 1] | (t >> (8 - (j & 7))));
+        }
+        j += PARAMS_P_BITS;
+    }
+#endif
+}
+
+// unpack a byte string into ND elements of p bits
+
+static void r5_unpack_p(modp_t *vp, const uint8_t *pv)
+{
+#if (PARAMS_P_BITS == 8)
+    memcpy(vp, pv, PARAMS_D);
+#else
+    size_t i, j;
+    modp_t t;
+
+    j = 0;
+    for (i = 0; i < PARAMS_D; i++) {
+        t = (modp_t) (pv[j >> 3] >> (j & 7)); // unpack p bits
+        if ((j & 7) + PARAMS_P_BITS > 8) {
+            t = (modp_t) (t | ((modp_t) pv[(j >> 3) + 1]) << (8 - (j & 7)));
+        }
+        vp[i] = t & (PARAMS_P - 1);
+        j += PARAMS_P_BITS;
+    }
+#endif
+}
+
+// generate a keypair (sigma, B)
+
+int r5_cpa_pke_keygen(uint8_t *pk, uint8_t *sk)
+{
+    modq_t a[2 * (PARAMS_D + 1)];
+    modq_t b[PARAMS_D];
+    uint16_t s_idx[PARAMS_H / 2][2];
+
+    randombytes(pk, PARAMS_KAPPA_BYTES); // sigma = seed of A
+
+    // A from sigma
+    r5_ring_a_random(a, pk);
+
+    randombytes(sk, PARAMS_KAPPA_BYTES); // secret key -- Random S
+    r5_create_secret_vec(s_idx, sk);
+
+    r5_ringmul_q(b, a, s_idx); // B = A * S
+
+    // Compress B q_bits -> p_bits, pk = sigma | B
+    r5_pack_q_p(pk + PARAMS_KAPPA_BYTES, b, PARAMS_H1);
+
+    return 0;
+}
+
+int r5_cpa_pke_encrypt(uint8_t *ct, const uint8_t *pk,
+    const uint8_t *m, const uint8_t *rho)
+{
+    size_t i, j;
+    modq_t a[2 * (PARAMS_D + 1)];
+    uint16_t r_idx[PARAMS_H / 2][2];
+    union {
+        modq_t u_t[PARAMS_D];
+        modp_t b[PARAMS_D + PARAMS_MU + 2];
+    } vec;
+    modp_t x[PARAMS_MU];
+    uint8_t m1[BITS_TO_BYTES(PARAMS_MU * PARAMS_B_BITS)];
+    modp_t t, tm;
+
+    // A from sigma
+    r5_ring_a_random(a, pk);
+
+    memcpy(m1, m, PARAMS_KAPPA_BYTES); // add error correction code
+    memset(m1 + PARAMS_KAPPA_BYTES, 0,
+        BITS_TO_BYTES(PARAMS_MU * PARAMS_B_BITS) - PARAMS_KAPPA_BYTES);
+#if (PARAMS_XE != 0)
+    xef_compute(m1, PARAMS_KAPPA_BYTES, PARAMS_F);
+#endif
+
+    // Create R
+    r5_create_secret_vec(r_idx, rho);
+
+    r5_ringmul_q(vec.u_t, a, r_idx);        // U^T = U = A^T * R = A * R (mod q)
+    r5_pack_q_p(ct, vec.u_t, PARAMS_H2);    // ct = U^T | v
+
+    // unpack public key
+    r5_unpack_p(vec.b, pk + PARAMS_KAPPA_BYTES);
+    r5_ringmul_p(x, vec.b, r_idx);      // X = B * R  (mod p)
+
+    memset(ct + PARAMS_NDP_SIZE, 0, PARAMS_MUT_SIZE);
+
+    j = 8 * PARAMS_NDP_SIZE;
+    for (i = 0; i < PARAMS_MU; i++) { // compute, pack v
+        // compress p->t
+        t = ((x[i] + PARAMS_H2) >> (PARAMS_P_BITS - PARAMS_T_BITS));
+        // add message
+        tm = (m1[(i * PARAMS_B_BITS) >> 3] >>
+                ((i * PARAMS_B_BITS) & 7));
+#if (8 % PARAMS_B_BITS != 0)
+        if (((i * PARAMS_B_BITS) & 7) + PARAMS_B_BITS > 8) {
+            /* Get spill over from next message byte */
+            tm = (tm | (m1[((i * PARAMS_B_BITS) >> 3) + 1]
+                    << (8 - ((i * PARAMS_B_BITS) & 7))));
+        }
+#endif
+        t = (t + ((tm & ((1 << PARAMS_B_BITS) - 1))
+            << (PARAMS_T_BITS - PARAMS_B_BITS))) & ((1 << PARAMS_T_BITS) - 1);
+
+        ct[j >> 3] = (ct[j >> 3] | (t << (j & 7))); // pack t bits
+        if ((j & 7) + PARAMS_T_BITS > 8) {
+            ct[(j >> 3) + 1] = (ct[(j >> 3) + 1] | (t >> (8 - (j & 7))));
+        }
+        j += PARAMS_T_BITS;
+    }
+
+    return 0;
+}
+
+int r5_cpa_pke_decrypt(uint8_t *m, const uint8_t *sk, const uint8_t *ct)
+{
+    size_t i, j;
+    uint16_t s_idx[PARAMS_H / 2][2];
+    modp_t u_t[PARAMS_D + PARAMS_MU + 2];
+    modp_t v[PARAMS_MU];
+    modp_t t, x_prime[PARAMS_MU];
+    uint8_t m1[BITS_TO_BYTES(PARAMS_MU * PARAMS_B_BITS)];
+
+    r5_create_secret_vec(s_idx, sk);
+
+    r5_unpack_p(u_t, ct); // ct = U^T | v
+
+    j = 8 * PARAMS_NDP_SIZE;
+    for (i = 0; i < PARAMS_MU; i++) {
+        t = (modp_t) (ct[j >> 3] >> (j & 7)); // unpack t bits
+        if ((j & 7) + PARAMS_T_BITS > 8) {
+            t = (modp_t) (t | ct[(j >> 3) + 1] << (8 - (j & 7)));
+        }
+        v[i] = t & ((1 << PARAMS_T_BITS) - 1);
+        j += PARAMS_T_BITS;
+    }
+
+    // X' = U * S (mod p)
+    r5_ringmul_p(x_prime, u_t, s_idx);
+
+    // X' = v - X', compressed to 1 bit
+    modp_t x_p;
+    memset(m1, 0, sizeof(m1));
+    for (i = 0; i < PARAMS_MU; i++) {
+        // v - X' as mod p value (to be able to perform the rounding!)
+        x_p = ((v[i] << (PARAMS_P_BITS - PARAMS_T_BITS)) - x_prime[i]);
+        x_p = (((x_p + PARAMS_H3) >> (PARAMS_P_BITS - PARAMS_B_BITS)) &
+                ((1 << PARAMS_B_BITS) - 1));
+        m1[(i * PARAMS_B_BITS) >> 3] = (m1[i * PARAMS_B_BITS >> 3] |
+                                        (x_p << ((i * PARAMS_B_BITS) & 7)));
+#if (8 % PARAMS_B_BITS != 0)
+        if (((i * PARAMS_B_BITS) & 7) + PARAMS_B_BITS > 8) {
+            /* Spill over to next message byte */
+            m1[(i * PARAMS_B_BITS >> 3) + 1] =
+                m1[((i * PARAMS_B_BITS) >> 3) + 1] |
+                    (x_p >> (8 - ((i * PARAMS_B_BITS) & 7)));
+        }
+#endif
+    }
+
+#if (PARAMS_XE != 0)
+    // Apply error correction
+    xef_compute(m1, PARAMS_KAPPA_BYTES, PARAMS_F);
+    xef_fixerr(m1, PARAMS_KAPPA_BYTES, PARAMS_F);
+#endif
+    memcpy(m, m1, PARAMS_KAPPA_BYTES);
+
+    return 0;
+}
+
+#endif
+

--- a/crypto_kem/r5nd-1kemcca-5d/opt/r5_matmul.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/r5_matmul.c
@@ -1,0 +1,111 @@
+//  r5_matmul.c
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+#include "r5_parameter_sets.h"
+
+#if (PARAMS_N == 1)
+
+#include <string.h>
+
+#include "r5_matmul.h"
+#include "r5_xof.h"
+#include "r5_addsub.h"
+#include "little_endian.h"
+
+// U = A_T * R
+
+void r5_matmul_ra_q(modq_t d[PARAMS_M_BAR][PARAMS_D],
+    modq_t a[PARAM_TAU2_A_RANDOM + PARAMS_D],
+    uint16_t a_perm[PARAMS_D],
+    uint16_t r_t[PARAMS_M_BAR][PARAMS_H / 2][2])
+{
+    size_t i, l;
+
+    // Initialize result
+    memset(d, 0, PARAMS_M_BAR * PARAMS_D * sizeof (modq_t));
+
+    for (l = 0; l < PARAMS_M_BAR; l++) {
+        for (i = 0; i < (PARAMS_H / 2) - 2; i += 3) {
+            r5_modq_addsub3_d(d[l],
+                &a[a_perm[r_t[l][i][0]]], &a[a_perm[r_t[l][i][1]]],
+                &a[a_perm[r_t[l][i + 1][0]]], &a[a_perm[r_t[l][i + 1][1]]],
+                &a[a_perm[r_t[l][i + 2][0]]], &a[a_perm[r_t[l][i + 2][1]]]);
+        }
+        while (i < PARAMS_H / 2) {
+            r5_modq_addsub_d(d[l],
+                &a[a_perm[r_t[l][i][0]]], &a[a_perm[r_t[l][i][1]]]);
+            i++;
+        }
+    }
+}
+
+// B = A * S
+
+void r5_matmul_as_q(modq_t d[PARAMS_D][PARAMS_N_BAR],
+    modq_t a[PARAM_TAU2_A_RANDOM + PARAMS_D],
+    uint16_t a_perm[PARAMS_D],
+    uint16_t s_t[PARAMS_N_BAR][PARAMS_H / 2][2])
+{
+    size_t i, l;
+
+    memset(d, 0, PARAMS_N_BAR * PARAMS_D * sizeof (modq_t));
+
+    for (l = 0; l < PARAMS_N_BAR; l++) {
+        for (i = 0; i < PARAMS_H / 2 - 2; i += 3) {
+            r5_modq_addsub3_perm_nbar_d(&d[0][l], a_perm,
+                &a[s_t[l][i][0]], &a[s_t[l][i][1]],
+                &a[s_t[l][i + 1][0]], &a[s_t[l][i + 1][1]],
+                &a[s_t[l][i + 2][0]], &a[s_t[l][i + 2][1]]);
+        }
+        while (i < PARAMS_H / 2) {
+            r5_modq_addsub_perm_nbar_d(&d[0][l], a_perm,
+                &a[s_t[l][i][0]], &a[s_t[l][i][1]]);
+            i++;
+        }
+    }
+}
+
+// X' = S_T * U
+
+void r5_matmul_us_p(modp_t d[PARAMS_MU],
+    modp_t u_t[PARAMS_M_BAR][PARAMS_D],
+    uint16_t s_t[PARAMS_N_BAR][PARAMS_H / 2][2])
+{
+    size_t i, j, k, idx;
+    modp_t t;
+
+    idx = 0;
+    for (i = 0; i < PARAMS_N_BAR && idx < PARAMS_MU; i++) {
+        for (j = 0; j < PARAMS_M_BAR && idx < PARAMS_MU; j++) {
+            t = 0;
+            for (k = 0; k < PARAMS_H / 2; k++) {
+                t += u_t[j][s_t[i][k][0]] - u_t[j][s_t[i][k][1]];
+            }
+            d[idx++] = t;
+        }
+    }
+}
+
+// X = B_T * R
+
+void r5_matmul_rb_p(modp_t d[PARAMS_MU],
+    modp_t b[PARAMS_D][PARAMS_N_BAR],
+    uint16_t r_t[PARAMS_M_BAR][PARAMS_H / 2][2])
+{
+    size_t i, j, l, idx;
+    modp_t t;
+
+    idx = 0;
+    for (l = 0; l < PARAMS_N_BAR && idx < PARAMS_MU; l++) {
+        for (j = 0; j < PARAMS_M_BAR && idx < PARAMS_MU; j++) {
+            t = 0;
+            for (i = 0; i < PARAMS_H / 2; i++) {
+                t += b[r_t[j][i][0]][l] - b[r_t[j][i][1]][l];
+            }
+            d[idx++] = t;
+        }
+    }
+}
+
+#endif
+

--- a/crypto_kem/r5nd-1kemcca-5d/opt/r5_matmul.h
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/r5_matmul.h
@@ -1,0 +1,31 @@
+//  r5_matmul.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+#ifndef _R5_MATMUL_H_
+#define _R5_MATMUL_H_
+
+#include "r5_parameter_sets.h"
+
+#if (PARAMS_N == 1)
+
+void r5_matmul_as_q(modq_t d[PARAMS_D][PARAMS_N_BAR],
+    modq_t a[PARAM_TAU2_A_RANDOM + PARAMS_D],
+    uint16_t a_perm[PARAMS_D],
+    uint16_t s_t[PARAMS_N_BAR][PARAMS_H / 2][2]);
+
+void r5_matmul_ra_q(modq_t d[PARAMS_M_BAR][PARAMS_D],
+    modq_t a[PARAM_TAU2_A_RANDOM + PARAMS_D],
+    uint16_t a_perm[PARAMS_D],
+    uint16_t r_t[PARAMS_M_BAR][PARAMS_H / 2][2]);
+
+void r5_matmul_us_p(modp_t d[PARAMS_MU],
+    modp_t u_t[PARAMS_M_BAR][PARAMS_D],
+    uint16_t s_t[PARAMS_N_BAR][PARAMS_H / 2][2]);
+
+void r5_matmul_rb_p(modp_t d[PARAMS_MU],
+    modp_t b[PARAMS_D][PARAMS_N_BAR],
+    uint16_t r_t[PARAMS_M_BAR][PARAMS_H / 2][2]);
+
+#endif
+
+#endif /* _R5_MATMUL_H_ */

--- a/crypto_kem/r5nd-1kemcca-5d/opt/r5_parameter_sets.h
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/r5_parameter_sets.h
@@ -1,0 +1,394 @@
+//  r5_parameter_sets.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+//  Markku-Juhani O. Saarinen, Koninklijke Philips N.V.
+
+#ifndef _R5_PARAMETER_SETS_H_
+#define _R5_PARAMETER_SETS_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+//  May or may not include the variant definiton
+#include "round5_variant_setting.h"
+
+//  Our NIST proposal parameter sets
+#if defined(R5ND_1KEM_0d)
+#define PARAMS_KAPPA_BYTES 16
+#define PARAMS_D           618
+#define PARAMS_N           618
+#define PARAMS_H           104
+#define PARAMS_Q_BITS      11
+#define PARAMS_P_BITS      8
+#define PARAMS_T_BITS      4
+#define PARAMS_B_BITS      1
+#define PARAMS_N_BAR       1
+#define PARAMS_M_BAR       1
+#define PARAMS_F           0
+#define PARAMS_XE          0
+#define CRYPTO_ALGNAME     "R5ND_1KEM_0d"
+
+#elif defined(R5ND_3KEM_0d)
+#define PARAMS_KAPPA_BYTES 24
+#define PARAMS_D           786
+#define PARAMS_N           786
+#define PARAMS_H           384
+#define PARAMS_Q_BITS      13
+#define PARAMS_P_BITS      9
+#define PARAMS_T_BITS      4
+#define PARAMS_B_BITS      1
+#define PARAMS_N_BAR       1
+#define PARAMS_M_BAR       1
+#define PARAMS_F           0
+#define PARAMS_XE          0
+#define CRYPTO_ALGNAME     "R5ND_3KEM_0d"
+
+#elif defined(R5ND_5KEM_0d)
+#define PARAMS_KAPPA_BYTES 32
+#define PARAMS_D           1018
+#define PARAMS_N           1018
+#define PARAMS_H           428
+#define PARAMS_Q_BITS      14
+#define PARAMS_P_BITS      9
+#define PARAMS_T_BITS      4
+#define PARAMS_B_BITS      1
+#define PARAMS_N_BAR       1
+#define PARAMS_M_BAR       1
+#define PARAMS_F           0
+#define PARAMS_XE          0
+#define CRYPTO_ALGNAME     "R5ND_5KEM_0d"
+
+#elif defined(R5ND_1PKE_0d)
+#define ROUND5_CCA_PKE
+#define PARAMS_KAPPA_BYTES 16
+#define PARAMS_D           586
+#define PARAMS_N           586
+#define PARAMS_H           182
+#define PARAMS_Q_BITS      13
+#define PARAMS_P_BITS      9
+#define PARAMS_T_BITS      4
+#define PARAMS_B_BITS      1
+#define PARAMS_N_BAR       1
+#define PARAMS_M_BAR       1
+#define PARAMS_F           0
+#define PARAMS_XE          0
+#define CRYPTO_ALGNAME     "R5ND_1PKE_0d"
+
+#elif defined(R5ND_3PKE_0d)
+#define ROUND5_CCA_PKE
+#define PARAMS_KAPPA_BYTES 24
+#define PARAMS_D           852
+#define PARAMS_N           852
+#define PARAMS_H           212
+#define PARAMS_Q_BITS      12
+#define PARAMS_P_BITS      9
+#define PARAMS_T_BITS      5
+#define PARAMS_B_BITS      1
+#define PARAMS_N_BAR       1
+#define PARAMS_M_BAR       1
+#define PARAMS_F           0
+#define PARAMS_XE          0
+#define CRYPTO_ALGNAME     "R5ND_3PKE_0d"
+
+#elif defined(R5ND_5PKE_0d)
+#define ROUND5_CCA_PKE
+#define PARAMS_KAPPA_BYTES 32
+#define PARAMS_D           1170
+#define PARAMS_N           1170
+#define PARAMS_H           222
+#define PARAMS_Q_BITS      13
+#define PARAMS_P_BITS      9
+#define PARAMS_T_BITS      5
+#define PARAMS_B_BITS      1
+#define PARAMS_N_BAR       1
+#define PARAMS_M_BAR       1
+#define PARAMS_F           0
+#define PARAMS_XE          0
+#define CRYPTO_ALGNAME     "R5ND_5PKE_0d"
+
+#elif defined(R5ND_1KEM_5d)
+#define PARAMS_KAPPA_BYTES 16
+#define PARAMS_D           490
+#define PARAMS_N           490
+#define PARAMS_H           162
+#define PARAMS_Q_BITS      10
+#define PARAMS_P_BITS      7
+#define PARAMS_T_BITS      3
+#define PARAMS_B_BITS      1
+#define PARAMS_N_BAR       1
+#define PARAMS_M_BAR       1
+#define PARAMS_F           5
+#define PARAMS_XE          190
+#define CRYPTO_ALGNAME     "R5ND_1KEM_5d"
+
+#elif defined(R5ND_3KEM_5d)
+#define PARAMS_KAPPA_BYTES 24
+#define PARAMS_D           756
+#define PARAMS_N           756
+#define PARAMS_H           242
+#define PARAMS_Q_BITS      12
+#define PARAMS_P_BITS      8
+#define PARAMS_T_BITS      2
+#define PARAMS_B_BITS      1
+#define PARAMS_N_BAR       1
+#define PARAMS_M_BAR       1
+#define PARAMS_F           5
+#define PARAMS_XE          218
+#define CRYPTO_ALGNAME     "R5ND_3KEM_5d"
+
+#elif defined(R5ND_5KEM_5d)
+#define PARAMS_KAPPA_BYTES 32
+#define PARAMS_D           940
+#define PARAMS_N           940
+#define PARAMS_H           414
+#define PARAMS_Q_BITS      12
+#define PARAMS_P_BITS      8
+#define PARAMS_T_BITS      2
+#define PARAMS_B_BITS      1
+#define PARAMS_N_BAR       1
+#define PARAMS_M_BAR       1
+#define PARAMS_F           5
+#define PARAMS_XE          234
+#define CRYPTO_ALGNAME     "R5ND_5KEM_5d"
+
+#elif defined(R5ND_1PKE_5d)
+#define ROUND5_CCA_PKE
+#define PARAMS_KAPPA_BYTES 16
+#define PARAMS_D           508
+#define PARAMS_N           508
+#define PARAMS_H           136
+#define PARAMS_Q_BITS      10
+#define PARAMS_P_BITS      7
+#define PARAMS_T_BITS      4
+#define PARAMS_B_BITS      1
+#define PARAMS_N_BAR       1
+#define PARAMS_M_BAR       1
+#define PARAMS_F           5
+#define PARAMS_XE          190
+#define CRYPTO_ALGNAME     "R5ND_1PKE_5d"
+
+#elif defined(R5ND_3PKE_5d)
+#define ROUND5_CCA_PKE
+#define PARAMS_KAPPA_BYTES 24
+#define PARAMS_D           756
+#define PARAMS_N           756
+#define PARAMS_H           242
+#define PARAMS_Q_BITS      12
+#define PARAMS_P_BITS      8
+#define PARAMS_T_BITS      3
+#define PARAMS_B_BITS      1
+#define PARAMS_N_BAR       1
+#define PARAMS_M_BAR       1
+#define PARAMS_F           5
+#define PARAMS_XE          218
+#define CRYPTO_ALGNAME     "R5ND_3PKE_5d"
+
+#elif defined(R5ND_5PKE_5d)
+#define ROUND5_CCA_PKE
+#define PARAMS_KAPPA_BYTES 32
+#define PARAMS_D           946
+#define PARAMS_N           946
+#define PARAMS_H           388
+#define PARAMS_Q_BITS      11
+#define PARAMS_P_BITS      8
+#define PARAMS_T_BITS      5
+#define PARAMS_B_BITS      1
+#define PARAMS_N_BAR       1
+#define PARAMS_M_BAR       1
+#define PARAMS_F           5
+#define PARAMS_XE          234
+#undef  CRYPTO_ALGNAME
+#define CRYPTO_ALGNAME     "R5ND_5PKE_5d"
+
+#elif defined(R5N1_1KEM_0d)
+#define PARAMS_KAPPA_BYTES 16
+#define PARAMS_D           594
+#define PARAMS_N           1
+#define PARAMS_H           238
+#define PARAMS_Q_BITS      13
+#define PARAMS_P_BITS      10
+#define PARAMS_T_BITS      7
+#define PARAMS_B_BITS      3
+#define PARAMS_N_BAR       7
+#define PARAMS_M_BAR       7
+#define PARAMS_F           0
+#define PARAMS_XE          0
+#define CRYPTO_ALGNAME     "R5N1_1KEM_0d"
+
+#elif defined(R5N1_3KEM_0d)
+#define PARAMS_KAPPA_BYTES 24
+#define PARAMS_D           881
+#define PARAMS_N           1
+#define PARAMS_H           238
+#define PARAMS_Q_BITS      13
+#define PARAMS_P_BITS      10
+#define PARAMS_T_BITS      7
+#define PARAMS_B_BITS      3
+#define PARAMS_N_BAR       8
+#define PARAMS_M_BAR       8
+#define PARAMS_F           0
+#define PARAMS_XE          0
+#define CRYPTO_ALGNAME     "R5N1_3KEM_0d"
+
+#elif defined(R5N1_5KEM_0d)
+#define PARAMS_KAPPA_BYTES 32
+#define PARAMS_D           1186
+#define PARAMS_N           1
+#define PARAMS_H           712
+#define PARAMS_Q_BITS      15
+#define PARAMS_P_BITS      12
+#define PARAMS_T_BITS      7
+#define PARAMS_B_BITS      4
+#define PARAMS_N_BAR       8
+#define PARAMS_M_BAR       8
+#define PARAMS_F           0
+#define PARAMS_XE          0
+#undef  CRYPTO_ALGNAME
+#define CRYPTO_ALGNAME     "R5N1_5KEM_0d"
+
+#elif defined(R5N1_1PKE_0d)
+#define ROUND5_CCA_PKE
+#define PARAMS_KAPPA_BYTES 16
+#define PARAMS_D           636
+#define PARAMS_N           1
+#define PARAMS_H           114
+#define PARAMS_Q_BITS      12
+#define PARAMS_P_BITS      9
+#define PARAMS_T_BITS      6
+#define PARAMS_B_BITS      2
+#define PARAMS_N_BAR       8
+#define PARAMS_M_BAR       8
+#define PARAMS_F           0
+#define PARAMS_XE          0
+#define CRYPTO_ALGNAME     "R5N1_1PKE_0d"
+
+#elif defined(R5N1_3PKE_0d)
+#define ROUND5_CCA_PKE
+#define PARAMS_KAPPA_BYTES 24
+#define PARAMS_D           876
+#define PARAMS_N           1
+#define PARAMS_H           446
+#define PARAMS_Q_BITS      15
+#define PARAMS_P_BITS      11
+#define PARAMS_T_BITS      7
+#define PARAMS_B_BITS      3
+#define PARAMS_N_BAR       8
+#define PARAMS_M_BAR       8
+#define PARAMS_F           0
+#define PARAMS_XE          0
+#define CRYPTO_ALGNAME     "R5N1_3PKE_0d"
+
+#elif defined(R5N1_5PKE_0d)
+#define ROUND5_CCA_PKE
+#define PARAMS_KAPPA_BYTES 32
+#define PARAMS_D           1217
+#define PARAMS_N           1
+#define PARAMS_H           462
+#define PARAMS_Q_BITS      15
+#define PARAMS_P_BITS      12
+#define PARAMS_T_BITS      9
+#define PARAMS_B_BITS      4
+#define PARAMS_N_BAR       8
+#define PARAMS_M_BAR       8
+#define PARAMS_F           0
+#define PARAMS_XE          0
+#define CRYPTO_ALGNAME     "R5N1_5PKE_0d"
+
+#elif defined(R5ND_0KEM_2iot)
+#define PARAMS_KAPPA_BYTES 16
+#define PARAMS_D           372
+#define PARAMS_N           372
+#define PARAMS_H           178
+#define PARAMS_Q_BITS      11
+#define PARAMS_P_BITS      7
+#define PARAMS_T_BITS      3
+#define PARAMS_B_BITS      1
+#define PARAMS_N_BAR       1
+#define PARAMS_M_BAR       1
+#define PARAMS_F           2
+#define PARAMS_XE          53
+#define CRYPTO_ALGNAME     "R5ND_0KEM_2iot"
+
+#elif defined(R5ND_1KEM_4longkey)
+#define PARAMS_KAPPA_BYTES 24
+#define PARAMS_D           490
+#define PARAMS_N           490
+#define PARAMS_H           162
+#define PARAMS_Q_BITS      10
+#define PARAMS_P_BITS      7
+#define PARAMS_T_BITS      3
+#define PARAMS_B_BITS      1
+#define PARAMS_N_BAR       1
+#define PARAMS_M_BAR       1
+#define PARAMS_F           4
+#define PARAMS_XE          163
+#define CRYPTO_ALGNAME     "R5ND_1KEM_4longkey"
+
+#else
+#error "Algorithm variant not defined"
+#endif
+
+// helper functions
+#define CEIL_DIV(a,b) ((a+b-1)/b)
+#define BITS_TO_BYTES(b) ((b + 7) / 8)
+
+// appropriate types
+typedef uint16_t modq_t;
+#if (PARAMS_P_BITS <= 8)
+typedef uint8_t modp_t;
+#else
+typedef uint16_t modp_t;
+#endif
+typedef uint8_t modt_t;
+
+#define PARAMS_Q        (1 << PARAMS_Q_BITS)
+#define PARAMS_Q_MASK   (PARAMS_Q - 1)
+#define PARAMS_P        (1 << PARAMS_P_BITS)
+#define PARAMS_P_MASK   (PARAMS_P - 1)
+#define PARAMS_KAPPA    (8 * PARAMS_KAPPA_BYTES)
+#define PARAMS_MU       CEIL_DIV((PARAMS_KAPPA + PARAMS_XE), PARAMS_B_BITS)
+#define PARAMS_MUT_SIZE BITS_TO_BYTES(PARAMS_MU * PARAMS_T_BITS)
+
+#define PARAMS_RS_DIV   (0x10000 / PARAMS_D)
+#define PARAMS_RS_LIM   (PARAMS_D * PARAMS_RS_DIV)
+#if (PARAMS_N == PARAMS_D)
+#define PARAMS_NDP_SIZE BITS_TO_BYTES(PARAMS_D * PARAMS_P_BITS)
+#else
+#define PARAMS_DP_SIZE  BITS_TO_BYTES(PARAMS_N_BAR * PARAMS_D * PARAMS_P_BITS)
+#define PARAMS_DPU_SIZE BITS_TO_BYTES(PARAMS_M_BAR * PARAMS_D * PARAMS_P_BITS)
+#endif
+
+// Rounding constants
+#if ((PARAMS_Q_BITS - PARAMS_P_BITS + PARAMS_T_BITS) < PARAMS_P_BITS)
+#define PARAMS_Z_BITS   PARAMS_P_BITS
+#else
+#define PARAMS_Z_BITS   (PARAMS_Q_BITS - PARAMS_P_BITS + PARAMS_T_BITS)
+#endif
+#define PARAMS_H1       (1 << (PARAMS_Q_BITS - PARAMS_P_BITS - 1))
+#define PARAMS_H2       (1 << (PARAMS_Q_BITS - PARAMS_Z_BITS - 1))
+#define PARAMS_H3       ((1 << (PARAMS_P_BITS - PARAMS_T_BITS - 1)) + (1 << (PARAMS_P_BITS - PARAMS_B_BITS - 1)) - (1 << (PARAMS_Q_BITS - PARAMS_Z_BITS - 1)))
+
+// Used for n=1 when Tau=2
+#define PARAM_TAU2_A_RANDOM 0x800
+
+// Public key and ciphertext
+
+#if (PARAMS_N == PARAMS_D)
+#define PARAMS_PK_SIZE  (PARAMS_KAPPA_BYTES + PARAMS_NDP_SIZE)
+#define PARAMS_CT_SIZE  (PARAMS_NDP_SIZE + PARAMS_MUT_SIZE)
+#else
+#define PARAMS_PK_SIZE  (PARAMS_KAPPA_BYTES + PARAMS_DP_SIZE)
+#define PARAMS_CT_SIZE  (PARAMS_DPU_SIZE + PARAMS_MUT_SIZE)
+#endif
+
+// Derive the NIST parameters
+
+// Using CCA_PKE as CCA-KEM requires these changes
+
+// CCA_KEM Variant
+#define CRYPTO_SECRETKEYBYTES  (PARAMS_KAPPA_BYTES + PARAMS_KAPPA_BYTES + PARAMS_PK_SIZE)
+#define CRYPTO_PUBLICKEYBYTES  PARAMS_PK_SIZE
+#define CRYPTO_BYTES           PARAMS_KAPPA_BYTES
+#define CRYPTO_CIPHERTEXTBYTES (PARAMS_CT_SIZE + PARAMS_KAPPA_BYTES)
+
+#endif /* _R5_PARAMETER_SETS_H_ */
+

--- a/crypto_kem/r5nd-1kemcca-5d/opt/r5_ringmul.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/r5_ringmul.c
@@ -1,0 +1,103 @@
+//  r5_ringmul.c
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  Fast ring arithmetic (without cache attack countermeasures)
+
+#include "r5_parameter_sets.h"
+
+#if (PARAMS_N == PARAMS_D)
+
+#include <string.h>
+
+#include "r5_ringmul.h"
+#include "r5_xof.h"
+#include "r5_addsub.h"
+#include "little_endian.h"
+
+// multiplication mod q, result length n
+
+void r5_ringmul_q(modq_t d[PARAMS_D],
+    modq_t a[2 * (PARAMS_D + 1)],
+    uint16_t idx[PARAMS_H / 2][2])
+{
+    size_t i;
+
+    //  note: order of coefficients a[1..n] is *NOT* reversed!
+    //  "lift" -- multiply by (x - 1)
+    a[PARAMS_D] = a[PARAMS_D - 1];
+    for (i = PARAMS_D - 1; i >= 1; i--) {
+        a[i] = a[i - 1] - a[i];
+    }
+    a[0] = -a[0];
+
+    //  duplicate at the end
+    memcpy(&a[PARAMS_D + 1], a, (PARAMS_D + 1) * sizeof(modq_t));
+
+    //  initialize result
+    memset(d, 0, PARAMS_D * sizeof (modq_t));
+
+    for (i = 0; i < (PARAMS_H / 2) - 2; i += 3) {
+        r5_modq_addsub3_d(d, &a[(PARAMS_D + 1) - idx[i][0]],
+                          &a[(PARAMS_D + 1) - idx[i][1]],
+                          &a[(PARAMS_D + 1) - idx[i + 1][0]],
+                          &a[(PARAMS_D + 1) - idx[i + 1][1]],
+                          &a[(PARAMS_D + 1) - idx[i + 2][0]],
+                          &a[(PARAMS_D + 1) - idx[i + 2][1]]);
+    }
+
+    while (i < PARAMS_H / 2) {
+        r5_modq_addsub_d(d, &a[(PARAMS_D + 1) - idx[i][0]],
+                         &a[(PARAMS_D + 1) - idx[i][1]]);
+        i++;
+    }
+
+    //  "unlift"
+    d[0] = -d[0];
+    for (i = 1; i < PARAMS_D; i++) {
+        d[i] = d[i - 1] - d[i];
+    }
+}
+
+// multiplication mod p, result length mu
+
+void r5_ringmul_p(modp_t d[PARAMS_MU],
+    modp_t a[PARAMS_D + PARAMS_MU + 2],
+    uint16_t idx[PARAMS_H / 2][2])
+{
+    size_t i;
+
+    //  note: order of coefficients p[1..N] is *NOT* reversed!
+#if (PARAMS_XE == 0) && (PARAMS_F == 0)
+    //  without error correction we "lift" -- i.e. multiply by (x - 1)
+    a[PARAMS_D] = a[PARAMS_D - 1];
+    for (i = PARAMS_D - 1; i >= 1; i--) {
+        a[i] = a[i - 1] - a[i];
+    }
+    a[0] = -a[0];
+#else
+    a[PARAMS_D] = 0;
+    a[PARAMS_D + 1] = a[0];
+    a++;                                //  don't lift, shift!
+#endif
+
+    memcpy(&a[PARAMS_D + 1], a, PARAMS_MU * sizeof (modp_t));
+
+    //  initialize result
+    memset(d, 0, (PARAMS_MU) * sizeof(modp_t));
+
+    for (i = 0; i < PARAMS_H / 2; i++) {
+        r5_modp_addsub_mu(d,
+            &a[PARAMS_D + 1 - idx[i][0]], &a[PARAMS_D + 1 - idx[i][1]]);
+    }
+
+#if (PARAMS_XE == 0) && (PARAMS_F == 0)
+    //  without error correction we "lifted" so we now need to "unlift"
+    d[0] = -d[0];
+    for (i = 1; i < PARAMS_MU; ++i) {
+        d[i] = d[i - 1] - d[i];
+    }
+#endif
+}
+
+#endif
+

--- a/crypto_kem/r5nd-1kemcca-5d/opt/r5_ringmul.h
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/r5_ringmul.h
@@ -1,0 +1,23 @@
+//  r5_ringmul.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+#ifndef _R5_RINGMUL_H_
+#define _R5_RINGMUL_H_
+
+#include "r5_parameter_sets.h"
+
+#if (PARAMS_N == PARAMS_D)
+
+// multiplication mod q, result length n
+void r5_ringmul_q(modq_t d[PARAMS_D],
+    modq_t a[2 * (PARAMS_D + 1)],
+    uint16_t idx[PARAMS_H / 2][2]);
+
+// multiplication mod p, result length mu
+void r5_ringmul_p(modp_t d[PARAMS_D],
+    modp_t a[PARAMS_D + PARAMS_MU + 2],
+    uint16_t idx[PARAMS_H / 2][2]);
+
+#endif
+
+#endif /* _R5_RINGMUL_H_ */

--- a/crypto_kem/r5nd-1kemcca-5d/opt/r5_xof.h
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/r5_xof.h
@@ -1,0 +1,57 @@
+//  r5_xof.h
+//  2019-03-26  Markku-Juhani O. Saarinen <mjos@pqshield.com>
+//  Copyright (c) 2019, PQShield Ltd.
+
+//  Abstract interface to an extensible output function ("XOF") type hash.
+//  Allows only one "input", but you can call "squeeze" many times.
+
+#ifndef _R5_XOF_H_
+#define _R5_XOF_H_
+
+#include "r5_parameter_sets.h"
+
+#ifndef BLNK2
+
+//  -- Keccak-based functionality --
+
+#include "fips202.h"
+
+#if (PARAMS_KAPPA_BYTES > 16)
+typedef shake256incctx r5_xof_ctx_t;
+#else
+typedef shake128incctx r5_xof_ctx_t;
+#endif
+
+// In Round5 SHAKE is used for everything, so hash = xof
+#define r5_hash r5_xof
+
+#else   /* !BLNK2 */
+
+//  -- SNEIK-based functionality --
+
+#include "blnk.h"
+typedef blnk_t r5_xof_ctx_t;
+
+// In R5SNEIK the CCA transform uses a SNEIKHA while seed expansion is SNEIGEN
+void r5_hash(void *out, const size_t out_len,
+    const void *in, const size_t in_len);
+
+#endif  /* BLNK2 */
+
+//  Common interface
+
+void r5_xof(void *out, const size_t out_len,
+    const void *in, const size_t in_len);
+
+void r5_xof_input(r5_xof_ctx_t *ctx,
+    const void *in, size_t in_len);
+
+void r5_xof_s_input(r5_xof_ctx_t *ctx,
+    const void *in, size_t in_len,
+    const void *sstr, size_t sstr_len);
+
+void r5_xof_squeeze(r5_xof_ctx_t *ctx,
+    void *out, size_t out_len);
+
+#endif /* _R5_XOF_H_ */
+

--- a/crypto_kem/r5nd-1kemcca-5d/opt/r5_xof_shake.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/r5_xof_shake.c
@@ -1,0 +1,63 @@
+//  r5_xof_shake.c
+//  2019-03-26  Markku-Juhani O. Saarinen <mjos@pqshield.com>
+//  Copyright (c) 2019, PQShield Ltd.
+
+#ifndef BLNK2
+
+#include "r5_xof.h"
+#include "sp800-185.h"
+
+#include <assert.h>
+#include <string.h>
+
+void r5_xof_input(r5_xof_ctx_t *ctx,
+    const void *in, size_t in_len)
+{
+#if (PARAMS_KAPPA_BYTES > 16)
+    shake256_inc_init(ctx);
+    shake256_inc_absorb(ctx, in, in_len);
+    shake256_inc_finalize(ctx);
+#else
+    shake128_inc_init(ctx);
+    shake128_inc_absorb(ctx, in, in_len);
+    shake128_inc_finalize(ctx);
+#endif
+}
+
+void r5_xof_squeeze(r5_xof_ctx_t *ctx,
+    void *out, size_t out_len)
+{
+#if (PARAMS_KAPPA_BYTES > 16)
+    shake256_inc_squeeze(out, out_len, ctx);
+#else
+    shake128_inc_squeeze(out, out_len, ctx);
+#endif
+}
+
+void r5_xof(void *out, size_t out_len,
+    const void *in, size_t in_len)
+{
+#if (PARAMS_KAPPA_BYTES > 16)
+    shake256(out, out_len, in, in_len);
+#else
+    shake128(out, out_len, in, in_len);
+#endif
+}
+
+
+void r5_xof_s_input(r5_xof_ctx_t *ctx,
+    const void *in, size_t in_len,
+    const void *sstr, size_t sstr_len)
+{
+#if (PARAMS_KAPPA_BYTES > 16)
+    cshake256_inc_init(ctx, (const uint8_t *)"", 0, sstr, sstr_len);
+    cshake256_inc_absorb(ctx, in, in_len);
+    cshake256_inc_finalize(ctx);
+#else
+    cshake128_inc_init(ctx, (const uint8_t *)"", 0, sstr, sstr_len);
+    cshake128_inc_absorb(ctx, in, in_len);
+    cshake128_inc_finalize(ctx);
+#endif
+}
+
+#endif /* !BLNK2 */

--- a/crypto_kem/r5nd-1kemcca-5d/opt/r5_xof_shake.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/r5_xof_shake.c
@@ -2,9 +2,10 @@
 //  2019-03-26  Markku-Juhani O. Saarinen <mjos@pqshield.com>
 //  Copyright (c) 2019, PQShield Ltd.
 
+#include "r5_xof.h"
+
 #ifndef BLNK2
 
-#include "r5_xof.h"
 #include "sp800-185.h"
 
 #include <assert.h>
@@ -43,7 +44,6 @@ void r5_xof(void *out, size_t out_len,
     shake128(out, out_len, in, in_len);
 #endif
 }
-
 
 void r5_xof_s_input(r5_xof_ctx_t *ctx,
     const void *in, size_t in_len,

--- a/crypto_kem/r5nd-1kemcca-5d/opt/r5_xof_sneik.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/r5_xof_sneik.c
@@ -2,12 +2,13 @@
 //  2019-03-26  Markku-Juhani O. Saarinen <mjos@pqshield.com>
 //  Copyright (c) 2019, PQShield Ltd.
 
+#include "r5_xof.h"
+
 #ifdef BLNK2
 
 //  For XOF we use the SNEIGEN entropy expansion function
 //  The hash used in CCA transform is SNEIKHA
 
-#include "r5_xof.h"
 #include "blnk.h"
 
 //  Initialize and absorb a message

--- a/crypto_kem/r5nd-1kemcca-5d/opt/r5_xof_sneik.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/r5_xof_sneik.c
@@ -1,0 +1,80 @@
+//  r5_xof_sneik.c
+//  2019-03-26  Markku-Juhani O. Saarinen <mjos@pqshield.com>
+//  Copyright (c) 2019, PQShield Ltd.
+
+#ifdef BLNK2
+
+//  For XOF we use the SNEIGEN entropy expansion function
+//  The hash used in CCA transform is SNEIKHA
+
+#include "r5_xof.h"
+#include "blnk.h"
+
+//  Initialize and absorb a message
+
+void r5_xof_input(r5_xof_ctx_t *ctx,
+    const void *in, size_t in_len)
+{
+    blnk_clr(ctx, SNEIGEN_RATE, SNEIGEN_ROUNDS);    // initialize
+
+    blnk_put(ctx, BLNK_AD, in, in_len);             // absorb input
+    blnk_fin(ctx, BLNK_AD);
+}
+
+//  Additional customizer "S"
+
+void r5_xof_s_input(r5_xof_ctx_t *ctx,
+    const void *in, size_t in_len,
+    const void *sstr, size_t sstr_len)
+{
+    blnk_clr(ctx, SNEIGEN_RATE, SNEIGEN_ROUNDS);    // initialize
+
+    blnk_put(ctx, BLNK_AD, sstr, sstr_len);         // absorb s
+    blnk_fin(ctx, BLNK_AD);                         // padding
+    blnk_put(ctx, BLNK_AD, in, in_len);             // absorb main input
+    blnk_fin(ctx, BLNK_AD);                         // another padding
+}
+
+//  Output bytes
+
+void r5_xof_squeeze(r5_xof_ctx_t *ctx,
+    void *out, size_t out_len)
+{
+    blnk_get(ctx, BLNK_HASH, out, out_len);         // squeeze output
+}
+
+//  Single-call interface: XOF is SNEIGEN
+
+void r5_xof(void *out, const size_t out_len,
+    const void *in, const size_t in_len)
+{
+    blnk_t ctx;
+
+    blnk_clr(&ctx, SNEIGEN_RATE, SNEIGEN_ROUNDS);   // initialize
+
+    blnk_put(&ctx, BLNK_AD, in, in_len);            // absorb input
+    blnk_fin(&ctx, BLNK_AD);
+    blnk_get(&ctx, BLNK_HASH, out, out_len);        // squeeze output
+}
+
+
+//  Single-call interface: Hash is SNEIKHA (only used by CCA transforms)
+
+#ifdef ROUND5_CCA_PKE
+
+void r5_hash(void *out, const size_t out_len,
+    const void *in, const size_t in_len)
+{
+    blnk_t ctx;
+
+    blnk_clr(&ctx, SNEIKHA_RATE, SNEIKHA_ROUNDS);   // initialize
+
+    blnk_put(&ctx, BLNK_AD, in, in_len);            // absorb input
+    blnk_fin(&ctx, BLNK_AD);
+    blnk_get(&ctx, BLNK_HASH, out, out_len);        // squeeze output
+}
+
+#endif /* ROUND5_CCA_PKE */
+
+#endif /* BLNK2 */
+

--- a/crypto_kem/r5nd-1kemcca-5d/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/round5_variant_setting.h
@@ -1,0 +1,7 @@
+//  round5_variant_setting.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
+#define R5ND_1KEM_5d
+#define ROUND5_CCA_PKE
+

--- a/crypto_kem/r5nd-1kemcca-5d/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/sneik_f512_c99.c
@@ -1,0 +1,79 @@
+//  sneik_f512_c99.c
+//  2019-02-18  Markku-Juhani O. Saarinen <mjos@pqshield.com>
+//  Copyright (C) 2019, PQShield Ltd. Please see LICENSE.
+
+#if !defined(ARMV7_ASM) && defined(BLNK2)
+
+//  SNEIK f512 v1.1 implementation for a generic 32-bit C99 target.
+
+#include <stdint.h>
+
+#ifndef ROR32
+#define ROR32(x, y) (((x) >> (y)) | ((x) << (32 - (y))))
+#endif
+
+#define MIX_F(pos, vec, t0, t1, t2, t3) {       \
+    t0 += t3;                                   \
+    t0 = t0 ^ ROR32(t0, 7) ^ ROR32(t0, 8);      \
+    t0 ^= ROR32(t2, 31);                        \
+    t2 = vec[(pos + 2) & 0xF];                  \
+    t0 += t2;                                   \
+    t0 = t0 ^ ROR32(t0, 15) ^ ROR32(t0, 23);    \
+    t0 ^= t1;                                   \
+    vec[pos] = t0;                              \
+}
+
+void sneik_f512(void *state, uint8_t dom, uint8_t rounds)
+{
+    const uint8_t rc[] = {
+        0xEF, 0xE0, 0xD9, 0xD6, 0xBA, 0xB5, 0x8C, 0x83,
+        0x10, 0x1F, 0x26, 0x29, 0x45, 0x4A, 0x73, 0x7C  // (only 8 used now)
+    };
+
+    int i;
+    uint32_t sv[16];
+    uint32_t w0, w1, w2, w3;
+
+    for (i = 0; i < 16; i++) {
+        sv[i] = ((uint32_t) ((uint8_t *) state)[4 * i]) |
+            (((uint32_t) ((uint8_t *) state)[4 * i + 1]) << 8) |
+            (((uint32_t) ((uint8_t *) state)[4 * i + 2]) << 16) |
+            (((uint32_t) ((uint8_t *) state)[4 * i + 3]) << 24);
+    }
+
+    w0 = sv[0];
+    w1 = sv[1];
+    w2 = sv[14];
+    w3 = sv[15];
+
+    for (i = 0; i < rounds; i++) {
+        w0 ^= (uint32_t) rc[i];
+        w1 ^= (uint32_t) dom;
+        MIX_F(  0,  sv, w0, w1, w2, w3 );
+        MIX_F(  1,  sv, w1, w2, w3, w0 );
+        MIX_F(  2,  sv, w2, w3, w0, w1 );
+        MIX_F(  3,  sv, w3, w0, w1, w2 );
+        MIX_F(  4,  sv, w0, w1, w2, w3 );
+        MIX_F(  5,  sv, w1, w2, w3, w0 );
+        MIX_F(  6,  sv, w2, w3, w0, w1 );
+        MIX_F(  7,  sv, w3, w0, w1, w2 );
+        MIX_F(  8,  sv, w0, w1, w2, w3 );
+        MIX_F(  9,  sv, w1, w2, w3, w0 );
+        MIX_F(  10, sv, w2, w3, w0, w1 );
+        MIX_F(  11, sv, w3, w0, w1, w2 );
+        MIX_F(  12, sv, w0, w1, w2, w3 );
+        MIX_F(  13, sv, w1, w2, w3, w0 );
+        MIX_F(  14, sv, w2, w3, w0, w1 );
+        MIX_F(  15, sv, w3, w0, w1, w2 );
+    }
+
+    for (i = 0; i < 16; i++) {
+        ((uint8_t *) state)[4 * i] = (uint8_t) sv[i] & 0xFF;
+        ((uint8_t *) state)[4 * i + 1] = (uint8_t) (sv[i] >> 8) & 0xFF;
+        ((uint8_t *) state)[4 * i + 2] = (uint8_t) (sv[i] >> 16) & 0xFF;
+        ((uint8_t *) state)[4 * i + 3] = (uint8_t) (sv[i] >> 24) & 0xFF;
+    }
+}
+
+#endif /* !ARMV7_ASM && BLNK2 */
+

--- a/crypto_kem/r5nd-1kemcca-5d/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/sneik_f512_c99.c
@@ -2,11 +2,14 @@
 //  2019-02-18  Markku-Juhani O. Saarinen <mjos@pqshield.com>
 //  Copyright (C) 2019, PQShield Ltd. Please see LICENSE.
 
+#include "round5_variant_setting.h"
+
 #if !defined(ARMV7_ASM) && defined(BLNK2)
 
 //  SNEIK f512 v1.1 implementation for a generic 32-bit C99 target.
 
 #include <stdint.h>
+#include "sneik_param.h"
 
 #ifndef ROR32
 #define ROR32(x, y) (((x) >> (y)) | ((x) << (32 - (y))))

--- a/crypto_kem/r5nd-1kemcca-5d/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/sneik_f512_c99.c
@@ -4,7 +4,7 @@
 
 #include "round5_variant_setting.h"
 
-#if !defined(ARMV7_ASM) && defined(BLNK2)
+#ifdef BLNK2
 
 //  SNEIK f512 v1.1 implementation for a generic 32-bit C99 target.
 
@@ -78,5 +78,5 @@ void sneik_f512(void *state, uint8_t dom, uint8_t rounds)
     }
 }
 
-#endif /* !ARMV7_ASM && BLNK2 */
+#endif /* BLNK2 */
 

--- a/crypto_kem/r5nd-1kemcca-5d/opt/sneik_param.h
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/sneik_param.h
@@ -1,0 +1,85 @@
+//  sneik_param.h
+//  2019-02-19  Markku-Juhani O. Saarinen <mjos@pqshield.com>
+//  Copyright (C) 2019, PQShield Ltd. Please see LICENSE.
+
+//  This file provides a BLNK2 instantations with the SNEIK permutation.
+
+#ifndef _SNEIK_PARAM_H_
+#define _SNEIK_PARAM_H_
+
+#include <stdint.h>
+#include "api.h"
+
+// Cryptographic permutation prototype
+void sneik_f512(void *state, uint8_t dom, uint8_t rounds);
+
+// Parameters (sizes are in bytes)
+#define BLNK_BLOCK 64
+
+// Profile the permutation ?
+#ifdef XOF_PROF
+extern uint32_t perm_count[];
+#define BLNK_PI(x, dom, rounds) {\
+    perm_count[rounds]++;\
+    sneik_f512(x, dom, rounds); }
+#else
+// no profiling
+#define BLNK_PI(x, dom, rounds) sneik_f512(x, dom, rounds)
+#endif /* XOF_PROF */
+
+// == SNEIKEN AEADs ==
+
+#define SNEIKEN_RATE (BLNK_BLOCK - PARAMS_KAPPA_BYTES)
+
+//  number of rounds for encryption
+#if (PARAMS_KAPPA_BYTES <= 16)
+#define SNEIKEN_ROUNDS 6
+#elif (PARAMS_KAPPA_BYTES <= 24)
+#define SNEIKEN_ROUNDS 7
+#elif (PARAMS_KAPPA_BYTES <= 32)
+#define SNEIKEN_ROUNDS 8
+#elif (PARAMS_KAPPA_BYTES <= 48)
+#define SNEIKEN_ROUNDS 8
+#else
+#error "SNEIKEN: Could not determine security level."
+#endif
+
+//  == SNEIKHA Cryptographic Hashes ==
+
+//  number of rounds for hashing
+#if (PARAMS_KAPPA_BYTES <= 16)
+#define SNEIKHA_ROUNDS 6
+#define SNEIKHA_RATE 32
+#elif (PARAMS_KAPPA_BYTES <= 32)
+#define SNEIKHA_ROUNDS 8
+#define SNEIKHA_RATE 16
+#elif (PARAMS_KAPPA_BYTES <= 48)
+#define SNEIKHA_ROUNDS 12
+#define SNEIKHA_RATE 8
+#else
+#error "SNEIKHA: Could not determine security level."
+#endif
+
+//  == SNEIGEN Entropy distribution function ==
+
+#ifdef PARAMS_KAPPA_BYTES
+
+#define SNEIGEN_RATE (BLNK_BLOCK - PARAMS_KAPPA_BYTES)
+
+//  number of rounds for entropy diffusion
+#if (PARAMS_KAPPA_BYTES <= 8)
+#define SNEIGEN_ROUNDS 2
+#elif (PARAMS_KAPPA_BYTES <= 16)
+#define SNEIGEN_ROUNDS 3
+#elif (PARAMS_KAPPA_BYTES <= 24)
+#define SNEIGEN_ROUNDS 4
+#elif (PARAMS_KAPPA_BYTES <= 32)
+#define SNEIGEN_ROUNDS 5
+#else
+#error "SNEIGEN: Could not determine security level."
+#endif
+
+#endif /* PARAMS_KAPPA_BYTES */
+
+#endif  /* _SNEIK_PARAM_H_ */
+

--- a/crypto_kem/r5nd-1kemcca-5d/opt/xe2_c16.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/xe2_c16.c
@@ -1,0 +1,87 @@
+//  Copyright (c) 2019, PQShield Ltd.
+//  Markku-Juhani O. Saarinen <mjos@pqshield.com>
+
+//  Optimized XE2-53 for "2iot" parameter set. Runs well even on 16-bit MCUs.
+
+#include "r5_parameter_sets.h"
+
+#if (PARAMS_F == 2 && PARAMS_XE == 53)
+
+#include "xef.h"
+#include "little_endian.h"
+
+#define XM16_RTLM(r, n) \
+    { r = ((r << (16 % n)) | (r >> (n - (16 % n)))) & ((1 << n) - 1); }
+#define XM16_FLDM(r, n) \
+    { r = (r ^ ((r >> n))) & ((1 << n) - 1); }
+#define XM16_UNFM(r, n) \
+    { r &= (uint16_t) ((1 << n) - 1); r |= (uint16_t) (r << n); }
+#define XM16_ROTR(r, n) \
+    { r = (uint16_t) ((r >> (16 % n)) | (r << (n - (16 % n)))); }
+
+//  == XE5-53 (128-bit payload) ==
+
+void xe2_53_compute(void *block)
+{
+    int i;
+    uint16_t r11, r13, r14, r15;
+    uint16_t *p16, x;
+
+    // initialize
+    p16 = (uint16_t *) block;
+    r11 = r13 = r14 = r15 = LITTLE_ENDIAN16(p16[7]);
+
+    for (i = 7; i >= 0; i--) {
+        if (i < 7) {
+            XM16_RTLM(r11, 11); XM16_RTLM(r13, 13);
+            XM16_RTLM(r14, 14); XM16_RTLM(r15, 15);
+
+            x = LITTLE_ENDIAN16(p16[i]);
+            r11 ^= x;   r13 ^= x;
+            r14 ^= x;   r15 ^= x;
+        }
+        XM16_FLDM(r11, 11); XM16_FLDM(r13, 13);
+        XM16_FLDM(r14, 14); XM16_FLDM(r15, 15);
+    }
+
+    // XE2-53:      r11 r13 r14 r15 end
+    // bit offset:  0   11  24  38  53
+    p16[8]  ^= LITTLE_ENDIAN16(r11 ^ (r13 << 11));
+    p16[9]  ^= LITTLE_ENDIAN16((r13 >> 5) ^ (r14 << 8));
+    p16[10] ^= LITTLE_ENDIAN16((r14 >> 8) ^ (r15 << 6));
+    *((uint8_t *) &p16[11]) ^= (uint8_t) ((r15 >> 10));
+}
+
+void xe2_53_fixerr(void *block)
+{
+    int i;
+    uint16_t r11, r13, r14, r15;
+    uint16_t *p16, x;
+
+    // decode
+    p16 = (uint16_t *) block;
+    x = LITTLE_ENDIAN16(p16[8]);
+    r11 = x; r13 = x >> 11;
+    x = LITTLE_ENDIAN16(p16[9]);
+    r13 ^= (uint16_t) (x << 5); r14 = x >> 8;
+    x = LITTLE_ENDIAN16(p16[10]);
+    r14 ^= (uint16_t) (x << 8); r15 = x >> 6;
+    x = (uint16_t) *((uint8_t *) &p16[11]);
+    r15 ^= (uint16_t) (x << 10);
+
+    XM16_UNFM(r11, 11); XM16_UNFM(r13, 13);
+    XM16_UNFM(r14, 14); XM16_UNFM(r15, 15);
+
+    for (i = 0; i < 8; i++) {
+        if (i > 0) {
+            // rotate
+            XM16_ROTR(r11, 11); XM16_ROTR(r13, 13);
+            XM16_ROTR(r14, 14); XM16_ROTR(r15, 15);
+        }
+        x = ((r11 | r13) & r14 & r15) | ((r11 & r13) & (r14 | r15));
+        p16[i] ^= LITTLE_ENDIAN16(x);
+    }
+}
+
+#endif
+

--- a/crypto_kem/r5nd-1kemcca-5d/opt/xe4_c64.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/xe4_c64.c
@@ -1,0 +1,119 @@
+//  Copyright (c) 2019, PQShield Ltd.
+//  Markku-Juhani O. Saarinen <mjos@pqshield.com>
+
+//  Optimized 64-bit "ANSI C" implementation of XE4-163
+
+#include "r5_parameter_sets.h"
+
+#if (PARAMS_F == 4 && PARAMS_XE == 163)
+
+#include "xef.h"
+#include "little_endian.h"
+
+// various bit-twiddling macros for 64-bit words
+
+#define XM64_RTLM(r, n) { r = ((r << (64 % n)) | (r >> (n - (64 % n)))) & \
+                                 ((1llu << n) - 1llu);}
+#define XM64_FLDM(r, n) { r = (r ^ ((r >> n))) & ((1llu << n) - 1llu); }
+#define XM64_FLD2(r, n) { r ^= r >> (2 * n); XM64_FLDM(r, n); }
+#define XM64_FLD4(r, n) { r ^= r >> (4 * n); XM64_FLD2(r, n); }
+
+#define XM64_PR16(r) { r ^= r >> 32; r = (r ^ (r >> 16)) & 0xFFFF; }
+#define XM64_UNFM(r, n) { r &= ((1llu << n) - 1llu); r |= r << n; }
+#define XM64_UNF2(r, n) { XM64_UNFM(r, n); r |= r << (2 * n); }
+#define XM64_UNF4(r, n) { XM64_UNF2(r, n); r |= r << (4 * n); }
+#define XM64_ROTR(r, n) { r = ((r >> (64 % n)) | (r << (n - (64 % n)))); }
+
+#define MX64_MJ8(c, t0, t1, t2, t3, v0, v1, v2, v3, v4, v5, v6, v7) \
+{ \
+    t1 = v0 & v1; t0 = v0 ^ v1; \
+    c = t0 & v2; t0 ^= v2; t1 ^= c; \
+    c = t0 & v3; t0 ^= v3; t1 ^= c; t2 = c & ~t1; \
+    c = t0 & v4; t0 ^= v4; t1 ^= c; c &= ~t1; t2 ^= c; \
+    c = t0 & v5; t0 ^= v5; t1 ^= c; c &= ~t1; t2 ^= c; \
+    c = t0 & v6; t0 ^= v6; t1 ^= c; c &= ~t1; t2 ^= c; \
+    c = t0 & v7; t0 ^= v7; t1 ^= c; c &= ~t1; t2 ^= c; t3 = c & ~t2; \
+    c = t0 | t1; t2 ^= c; t3 ^= c & ~t2; \
+}
+
+//  == XE4-163 (192-bit payload) ==
+
+void xe4_163_compute(void *block)
+{
+    int i;
+    uint64_t r13, r15, r16, r17, r19, r23, r29, r31;
+    uint64_t *p64, x;
+
+    // initialize
+    p64 = (uint64_t *) block;
+    r13 = r15 = r16 = r17 = r19 = r23 = r29 = r31 = LITTLE_ENDIAN64(p64[2]);
+
+    for (i = 2; i >= 0; i--) {
+        if (i < 2) {
+            // rotate
+            XM64_RTLM(r13, 13); XM64_RTLM(r15, 15);
+            XM64_RTLM(r17, 17); XM64_RTLM(r19, 19); XM64_RTLM(r23, 23);
+            XM64_RTLM(r29, 29); XM64_RTLM(r31, 31);
+
+            // xor
+            x = LITTLE_ENDIAN64(p64[i]);
+            r13 ^= x;   r15 ^= x;   r16 ^= x;
+            r17 ^= x;   r19 ^= x;   r23 ^= x;
+            r29 ^= x;   r31 ^= x;
+        }
+
+        // fold
+        XM64_FLD4(r13, 13); XM64_FLD4(r15, 15); XM64_PR16(r16);
+        XM64_FLD2(r17, 17); XM64_FLD2(r19, 19); XM64_FLD2(r23, 23);
+        XM64_FLD2(r29, 29); XM64_FLD2(r31, 31);
+    }
+
+    // XE4-163:     r13 r15 r16 r17 r19 r23 r29 r31 end
+    // bit offset:  0   13  28  44  61  80  103 132 163
+
+    x = r13 ^ (r15 << 13) ^ (r16 << 28) ^ (r17 << 44) ^ (r19 << 61);
+    p64[3] ^= LITTLE_ENDIAN64(x);
+    x = (r19 >> 3) ^ (r23 << 16) ^ (r29 << 39);
+    p64[4] ^= LITTLE_ENDIAN64(x);
+    x = (uint32_t) ((r29 >> 25) ^ (r31 << 4));
+    ((uint32_t *) block)[10] ^= LITTLE_ENDIAN32(x);
+    ((uint8_t *) block)[44] ^= (uint8_t) (r31 >> 28);
+}
+
+void xe4_163_fixerr(void *block)
+{
+    int i;
+    uint64_t r13, r15, r16, r17, r19, r23, r29, r31;
+    uint64_t *p64, x, c, t0, t1, t2;
+
+    // decode
+    p64 = (uint64_t *) block;
+    x = LITTLE_ENDIAN64(p64[3]);
+    r13 = x; r15 = x >> 13; r16 = x >> 28; r17 = x >> 44; r19 = x >> 61;
+    x = LITTLE_ENDIAN64(p64[4]);
+    r19 ^= x << 3; r23 = x >> 16; r29 = x >> 39;
+    x = LITTLE_ENDIAN32(((uint32_t *) block)[10]);
+    r29 ^= x << 25; r31 = x >> 4;
+    x = ((uint8_t *) block)[44];
+    r31 ^= x << 28;
+
+    // unfold
+    XM64_UNF4(r13, 13); XM64_UNF4(r15, 15); XM64_UNF2(r16, 16);
+    XM64_UNF2(r17, 17); XM64_UNF2(r19, 19); XM64_UNF2(r23, 23);
+    XM64_UNF2(r29, 29); XM64_UNF2(r31, 31);
+
+    for (i = 0; i < 3; i++) {
+        if (i > 0) {
+            // rotate
+            XM64_ROTR(r13, 13); XM64_ROTR(r15, 15);
+            XM64_ROTR(r17, 17); XM64_ROTR(r19, 19); XM64_ROTR(r23, 23);
+            XM64_ROTR(r29, 29); XM64_ROTR(r31, 31);
+        }
+        // majority
+        MX64_MJ8(c, t0, t1, t2, x,
+            r13, r15, r16, r17, r19, r23, r29, r31);
+        p64[i] ^= LITTLE_ENDIAN64(x);
+    }
+}
+
+#endif

--- a/crypto_kem/r5nd-1kemcca-5d/opt/xe5_c64.c
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/xe5_c64.c
@@ -1,0 +1,359 @@
+//  Copyright (c) 2019, PQShield Ltd.
+//  Markku-Juhani O. Saarinen <mjos@pqshield.com>
+
+//  Optimized 64-bit "ANSI C" implementation of XE5 codes (Round5 variant)
+
+#include "r5_parameter_sets.h"
+
+#if PARAMS_F == 5
+
+#include "xef.h"
+#include "little_endian.h"
+
+// various bit-twiddling macros for 64-bit words
+
+#define XM64_RTLM(r, n) { r = ((r << (64 % n)) | (r >> (n - (64 % n)))) & \
+                                 ((1llu << n) - 1llu);}
+#define XM64_FLDM(r, n) { r = (r ^ ((r >> n))) & ((1llu << n) - 1llu); }
+#define XM64_FLD2(r, n) { r ^= r >> (2 * n); XM64_FLDM(r, n); }
+#define XM64_FLD4(r, n) { r ^= r >> (4 * n); XM64_FLD2(r, n); }
+
+#define XM64_GTH8(r) { \
+    r ^= r >> 4; \
+    r ^= r >> 2; \
+    r ^= r >> 1; \
+    r &= 0x0101010101010101llu; \
+    r ^= r >> 7; \
+    r ^= r >> 14; \
+    r = (r ^ (r >> 28)) & 0xFF; \
+}
+
+#define XM64_GTH4(r) { \
+    r ^= r >> 8; \
+    r ^= r >> 4; \
+    r ^= r >> 2; \
+    r ^= r >> 1; \
+    r &= 0x0001000100010001llu; \
+    r ^= r >> 15; \
+    r = (r ^ (r >> 30)) & 0xF; \
+}
+
+#define XM64_PR16(r) { r ^= r >> 32; r = (r ^ (r >> 16)) & 0xFFFF; }
+#define XM64_UNFM(r, n) { r &= ((1llu << n) - 1llu); r |= r << n; }
+#define XM64_UNF2(r, n) { XM64_UNFM(r, n); r |= r << (2 * n); }
+#define XM64_UNF4(r, n) { XM64_UNF2(r, n); r |= r << (4 * n); }
+#define XM64_ROTR(r, n) { r = ((r >> (64 % n)) | (r << (n - (64 % n)))); }
+
+#define XM64_UNG8(r) { \
+    r |= r << 8; \
+    r |= r << 16; \
+    r |= r << 32; \
+    r &= 0x8040201008040201llu; \
+    r = (0x0080808080808080llu - r) & 0x8040404040404040llu; \
+    r |= ((r >> 63) << 62) | (r << 1); \
+    r |= r >> 2; \
+    r |= r >> 4; \
+}
+
+#define XM64_UNG4(r) { \
+    r |= r << 16; \
+    r |= r << 32; \
+    r &= 0x0008000400020001llu; \
+    r =  0x1000100010001000llu - r; \
+    r &= 0x0FF00FF00FF00FF0llu; \
+    r = (r << 4) | (r >> 4); \
+}
+
+#define MX64_MJ10(c, t0, t1, t2, t3, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9) \
+{ \
+    t1 = v0 & v1; t0 = v0 ^ v1; \
+    c = t0 & v2; t0 ^= v2; t1 ^= c; \
+    c = t0 & v3; t0 ^= v3; t1 ^= c; t2 = c & ~t1; \
+    c = t0 & v4; t0 ^= v4; t1 ^= c; c &= ~t1; t2 ^= c; \
+    c = t0 & v5; t0 ^= v5; t1 ^= c; c &= ~t1; t2 ^= c; \
+    c = t0 & v6; t0 ^= v6; t1 ^= c; c &= ~t1; t2 ^= c; \
+    c = t0 & v7; t0 ^= v7; t1 ^= c; c &= ~t1; t2 ^= c; t3 = c & ~t2; \
+    c = t0 & v8; t0 ^= v8; t1 ^= c; c &= ~t1; t2 ^= c; c &= ~t2; t3 ^= c; \
+    c = t0 & v9; t1 ^= c; c &= ~t1; t2 ^= c; c &= ~t2; t3 ^= c; \
+    t2 ^= t1; t3 ^= t1 & ~t2; \
+}
+
+//  == XE5-190 (128-bit payload) ==
+
+#if PARAMS_XE == 190
+
+void xe5_190_compute(void *block)
+{
+    uint64_t rp8, r11, r13, r16, r17, r19, r21, r23, r25, r29;
+    uint64_t *p64, x;
+
+    // initialize
+    p64 = (uint64_t *) block;
+    rp8 = r11 = r13 = r16 = r17 = r19 = r21 = r23 = r25 = r29 =
+        LITTLE_ENDIAN64(p64[1]);
+
+    // fold
+    XM64_GTH8(rp8);
+    XM64_FLD4(r11, 11); XM64_FLD4(r13, 13);
+    XM64_FLD2(r17, 17); XM64_FLD2(r19, 19); XM64_FLD2(r21, 21);
+    XM64_FLD2(r23, 23); XM64_FLD2(r25, 25); XM64_FLD2(r29, 29);
+
+    // rotate
+    XM64_RTLM(r11, 11); XM64_RTLM(r13, 13); XM64_RTLM(r17, 17);
+    XM64_RTLM(r19, 19); XM64_RTLM(r21, 21); XM64_RTLM(r23, 23);
+    XM64_RTLM(r25, 25); XM64_RTLM(r29, 29);
+
+    // xor
+    x = LITTLE_ENDIAN64(p64[0]);
+    r11 ^= x;   r13 ^= x;   r16 ^= x;
+    r17 ^= x;   r19 ^= x;   r21 ^= x;
+    r23 ^= x;   r25 ^= x;   r29 ^= x;
+
+    // fold
+    XM64_GTH8(x);
+    rp8 = (rp8 << 8) ^ x;
+    XM64_FLD4(r11, 11); XM64_FLD4(r13, 13); XM64_PR16(r16);
+    XM64_FLD2(r17, 17); XM64_FLD2(r19, 19); XM64_FLD2(r21, 21);
+    XM64_FLD2(r23, 23); XM64_FLD2(r25, 25); XM64_FLD2(r29, 29);
+
+    // XE5-190:     rp8 r11 r13 r16 r17 r19 r21 r23 r25 r29 end
+    // bit offset:  0   16  27  40  56  73  92  113 136 161 190
+    x = rp8 ^ (r11 << 16) ^ (r13 << 27) ^ (r16 << 40) ^ (r17 << 56);
+    p64[2] ^= LITTLE_ENDIAN64(x);
+    x = (r17 >> 8) ^ (r19 << 9) ^ (r21 << 28) ^ (r23 << 49);
+    p64[3] ^= LITTLE_ENDIAN64(x);
+    x = (r23 >> 15) ^ (r25 << 8) ^ (r29 << 33);
+    p64[4] ^= LITTLE_ENDIAN64(x);
+}
+
+void xe5_190_fixerr(void *block)
+{
+    uint64_t rp8, r11, r13, r16, r17, r19, r21, r23, r25, r29;
+    uint64_t *p64, x, y, c, t1, t2;
+
+    // decode
+    p64 = (uint64_t *) block;
+    x = LITTLE_ENDIAN64(p64[2]);
+    rp8 = x; r11 = x >> 16; r13 = x >> 27;  r16 = x >> 40;  r17 = x >> 56;
+    x = LITTLE_ENDIAN64(p64[3]);
+    r17 ^= x << 8; r19 = x >> 9; r21 = x >> 28; r23 = x >> 49;
+    x = LITTLE_ENDIAN64(p64[4]);
+    r23 ^= x << 15; r25 = x >> 8; r29 = x >> 33;
+
+    // unfold
+    y = rp8 & 0xFF;
+    XM64_UNG8(y);
+    XM64_UNF4(r11, 11); XM64_UNF4(r13, 13); XM64_UNF2(r16, 16);
+    XM64_UNF2(r17, 17); XM64_UNF2(r19, 19); XM64_UNF2(r21, 21);
+    XM64_UNF2(r23, 23); XM64_UNF2(r25, 25); XM64_UNF2(r29, 29);
+
+    // majority
+    MX64_MJ10(c, y, t1, t2, x,
+        y, r11, r13, r16, r17, r19, r21, r23, r25, r29);
+    p64[0] ^= LITTLE_ENDIAN64(x);
+
+    // rotate
+    y = (rp8 >> 8) & 0xFF;
+    XM64_UNG8(y);
+    XM64_ROTR(r11, 11); XM64_ROTR(r13, 13); XM64_ROTR(r17, 17);
+    XM64_ROTR(r19, 19); XM64_ROTR(r21, 21); XM64_ROTR(r23, 23);
+    XM64_ROTR(r25, 25); XM64_ROTR(r29, 29);
+
+    // majority
+    MX64_MJ10(c, y, t1, t2, x,
+        y, r11, r13, r16, r17, r19, r21, r23, r25, r29);
+    p64[1] ^= LITTLE_ENDIAN64(x);
+}
+
+#endif
+
+//  == XE5-218 (192-bit payload) ==
+
+#if PARAMS_XE == 218
+
+void xe5_218_compute(void *block)
+{
+    int i;
+    uint64_t rp8, r13, r16, r17, r19, r21, r23, r25, r29, r31;
+    uint64_t *p64, x;
+
+    // initialize
+    p64 = (uint64_t *) block;
+    rp8 = r13 = r16 = r17 = r19 = r21 = r23 = r25 = r29 = r31 =
+        LITTLE_ENDIAN64(p64[2]);
+    XM64_GTH8(rp8);
+
+    for (i = 2; i >= 0; i--) {
+        if (i < 2) {
+            // rotate
+            XM64_RTLM(r13, 13); XM64_RTLM(r17, 17); XM64_RTLM(r19, 19);
+            XM64_RTLM(r21, 21); XM64_RTLM(r23, 23); XM64_RTLM(r25, 25);
+            XM64_RTLM(r29, 29); XM64_RTLM(r31, 31);
+
+            // xor
+            x = LITTLE_ENDIAN64(p64[i]);
+            r13 ^= x;   r16 ^= x;   r17 ^= x;
+            r19 ^= x;   r21 ^= x;   r23 ^= x;
+            r25 ^= x;   r29 ^= x;   r31 ^= x;
+            XM64_GTH8(x);
+            rp8 = (rp8 << 8) ^ x;
+        }
+
+        // fold
+        XM64_FLD4(r13, 13); XM64_PR16(r16);     XM64_FLD2(r17, 17);
+        XM64_FLD2(r19, 19); XM64_FLD2(r21, 21); XM64_FLD2(r23, 23);
+        XM64_FLD2(r25, 25); XM64_FLD2(r29, 29); XM64_FLD2(r31, 31);
+    }
+
+    // XE5-218:     rp8 r13 r16 r17 r19 r21 r23 r25 r29 r31 end
+    // bit offset:  0   24  37  53  70  89  110 133 158 187 218
+    x = rp8 ^ (r13 << 24) ^ (r16 << 37) ^ (r17 << 53);
+    p64[3] ^= LITTLE_ENDIAN64(x);
+    x = (r17 >> 11) ^ (r19 << 6) ^ (r21 << 25) ^ (r23 << 46);
+    p64[4] ^= LITTLE_ENDIAN64(x);
+    x = (r23 >> 18) ^ (r25 << 5) ^ (r29 << 30) ^ (r31 << 59);
+    p64[5] ^= LITTLE_ENDIAN64(x);
+    *((uint32_t *) &p64[6]) ^= LITTLE_ENDIAN32(r31 >> 5);
+}
+
+void xe5_218_fixerr(void *block)
+{
+    int i;
+    uint64_t rp8, r13, r16, r17, r19, r21, r23, r25, r29, r31;
+    uint64_t *p64, x, y, c, t1, t2;
+
+    // decode
+    p64 = (uint64_t *) block;
+    x = LITTLE_ENDIAN64(p64[3]);
+    rp8 = x; r13 = x >> 24; r16 = x >> 37; r17 = x >> 53;
+    x = LITTLE_ENDIAN64(p64[4]);
+    r17 ^= x << 11; r19 = x >> 6; r21 = x >> 25; r23 = x >> 46;
+    x = LITTLE_ENDIAN64(p64[5]);
+    r23 ^= x << 18; r25 = x >> 5; r29 = x >> 30; r31 = x >> 59;
+    r31 ^= LITTLE_ENDIAN32(*((uint32_t *) &p64[6])) << 5;
+
+    // unfold
+    y = rp8 & 0xFF;
+    XM64_UNG8(y);
+    XM64_UNF4(r13, 13); XM64_UNF2(r16, 16); XM64_UNF2(r17, 17);
+    XM64_UNF2(r19, 19); XM64_UNF2(r21, 21); XM64_UNF2(r23, 23);
+    XM64_UNF2(r25, 25); XM64_UNF2(r29, 29); XM64_UNF2(r31, 31);
+
+    for (i = 0; i < 3; i++) {
+        if (i > 0) {
+            // rotate
+            rp8 >>= 8;
+            y = rp8 & 0xFF;
+            XM64_UNG8(y);
+            XM64_ROTR(r13, 13); XM64_ROTR(r17, 17); XM64_ROTR(r19, 19);
+            XM64_ROTR(r21, 21); XM64_ROTR(r23, 23); XM64_ROTR(r25, 25);
+            XM64_ROTR(r29, 29); XM64_ROTR(r31, 31);
+        }
+
+        // majority
+        MX64_MJ10(c, y, t1, t2, x,
+            y, r13, r16, r17, r19, r21, r23, r25, r29, r31);
+        p64[i] ^= LITTLE_ENDIAN64(x);
+    }
+}
+
+#endif
+
+//  == XE5-234 (256-bit payload) ==
+
+#if PARAMS_XE == 234
+
+void xe5_234_compute(void *block)
+{
+    int i;
+    uint64_t p16, r16, r17, r19, r21, r23, r25, r29, r31, r37;
+    uint64_t *p64, x;
+
+    // initialize
+    p64 = (uint64_t *) block;
+    p16 = r16 = r17 = r19 = r21 = r23 = r25 = r29 = r31 = r37 =
+        LITTLE_ENDIAN64(p64[3]);
+    XM64_GTH4(p16);
+
+    for (i = 3; i >= 0; i--) {
+        if (i < 3) {
+            // rotate
+            XM64_RTLM(r17, 17); XM64_RTLM(r19, 19); XM64_RTLM(r21, 21);
+            XM64_RTLM(r23, 23); XM64_RTLM(r25, 25); XM64_RTLM(r29, 29);
+            XM64_RTLM(r31, 31); XM64_RTLM(r37, 37);
+
+            // xor
+            x = LITTLE_ENDIAN64(p64[i]);
+            r16 ^= x;   r17 ^= x;   r19 ^= x;
+            r21 ^= x;   r23 ^= x;   r25 ^= x;
+            r29 ^= x;   r31 ^= x;   r37 ^= x;
+            XM64_GTH4(x);
+            p16 = (p16 << 4) ^ x;
+        }
+
+        // fold
+        XM64_PR16(r16);     XM64_FLD2(r17, 17); XM64_FLD2(r19, 19);
+        XM64_FLD2(r21, 21); XM64_FLD2(r23, 23); XM64_FLD2(r25, 25);
+        XM64_FLD2(r29, 29); XM64_FLD2(r31, 31); XM64_FLDM(r37, 37);
+    }
+
+    // XE5-234:     p16 r16 r17 r19 r21 r23 r25 r29 r31 r37 end
+    // bit offset:  0   16  32  49  68  89  112 137 166 197 234
+    x = p16 ^ (r16 << 16) ^ (r17 << 32) ^ (r19 << 49);
+    p64[4] ^= LITTLE_ENDIAN64(x);
+    x = (r19 >> 15) ^ (r21 << 4) ^ (r23 << 25) ^ (r25 << 48);
+    p64[5] ^= LITTLE_ENDIAN64(x);
+    x = (r25 >> 16) ^ (r29 << 9) ^ (r31 << 38);
+    p64[6] ^= LITTLE_ENDIAN64(x);
+    x = (r31 >> 26) ^ (r37 << 5);
+    ((uint32_t *) &p64[7])[0] ^= LITTLE_ENDIAN32(x);
+    ((uint16_t *) &p64[7])[2] ^= LITTLE_ENDIAN16(x >> 32);
+}
+
+void xe5_234_fixerr(void *block)
+{
+    int i;
+    uint64_t p16, r16, r17, r19, r21, r23, r25, r29, r31, r37;
+    uint64_t *p64, x, y, c, t1, t2;
+
+    // decode
+    p64 = (uint64_t *) block;
+
+    x = LITTLE_ENDIAN64(p64[4]);
+    p16 = x; r16 = x >> 16; r17 = x >> 32; r19 = x >> 49;
+    x = LITTLE_ENDIAN64(p64[5]);
+    r19 ^= x << 15; r21 = x >> 4; r23 = x >> 25; r25 = x >> 48;
+    x = LITTLE_ENDIAN64(p64[6]);
+    r25 ^= x << 16; r29 = x >> 9; r31 = x >> 38;
+    x = ((uint64_t) LITTLE_ENDIAN32(((uint32_t *) &p64[7])[0])) ^
+        ((uint64_t) LITTLE_ENDIAN16(((uint16_t *) &p64[7])[2]) << 32);
+    r31 ^= x << 26; r37 = x >> 5;
+
+    // unfold
+    y = p16 & 0xF;
+    XM64_UNG4(y);
+    XM64_UNF2(r16, 16); XM64_UNF2(r17, 17); XM64_UNF2(r19, 19);
+    XM64_UNF2(r21, 21); XM64_UNF2(r23, 23); XM64_UNF2(r25, 25);
+    XM64_UNF2(r29, 29); XM64_UNF2(r31, 31); XM64_UNFM(r37, 37);
+
+    for (i = 0; i < 4; i++) {
+        if (i > 0) {
+            // rotate
+            p16 >>= 4;
+            y = p16 & 0xF;
+            XM64_UNG4(y);
+            XM64_ROTR(r17, 17); XM64_ROTR(r19, 19); XM64_ROTR(r21, 21);
+            XM64_ROTR(r23, 23); XM64_ROTR(r25, 25); XM64_ROTR(r29, 29);
+            XM64_ROTR(r31, 31); XM64_ROTR(r37, 37);
+        }
+
+        // majority
+        MX64_MJ10(c, y, t1, t2, x,
+            y, r16, r17, r19, r21, r23, r25, r29, r31, r37);
+        p64[i] ^= LITTLE_ENDIAN64(x);
+    }
+}
+
+#endif
+
+#endif

--- a/crypto_kem/r5nd-1kemcca-5d/opt/xef.h
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/xef.h
@@ -1,0 +1,56 @@
+//  xef.h
+//  2018-10-25 Markku-Juhani O. Saarinen <mjos@pqshield.com>
+//  (c) 2018   PQShield Ltd. All Rights Reserved.
+
+//  Prototypes for error correction codes
+
+#ifndef _XEF_H_
+#define _XEF_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+//  Computes the parity code, XORs it at the end of payload
+//  len = payload (bytes). Returns (payload | xef) length in *bits*.
+//  size_t xef_compute(void *block, size_t len, unsigned f);
+
+//  Fixes errors based on parity code. Call xef_compute() first to get delta.
+//  len = payload (bytes). Returns (payload | xef) length in *bits*.
+//  size_t xef_fixerr(void *block, size_t len, unsigned f);
+
+
+void xe2_53_compute(void *block);       // xe2_c16.c
+void xe2_53_fixerr(void *block);
+
+void xe4_163_compute(void *block);      // xe4_c64.c
+void xe4_163_fixerr(void *block);
+
+void xe5_190_compute(void *block);      // xe5_c64.c
+void xe5_190_fixerr(void *block);
+void xe5_218_compute(void *block);
+void xe5_218_fixerr(void *block);
+void xe5_234_compute(void *block);
+void xe5_234_fixerr(void *block);
+
+/* Wrapper around xef functions so we can seamlessly make use of the optimized xe5 */
+
+#if PARAMS_F == 5
+#if PARAMS_XE == 190
+#define XEF(function, block, len, f) xe5_190_##function(block)
+#elif PARAMS_XE == 218
+#define XEF(function, block, len, f) xe5_218_##function(block)
+#elif PARAMS_XE == 234
+#define XEF(function, block, len, f) xe5_234_##function(block)
+#endif
+#elif PARAMS_F == 4 && PARAMS_XE == 163
+#define XEF(function, block, len, f) xe4_163_##function(block)
+#elif PARAMS_F == 2 && PARAMS_XE == 53
+#define XEF(function, block, len, f) xe2_53_##function(block)
+#else
+#define XEF(function, block, len, f) xef_##function(block, len, f)
+#endif
+
+#define xef_compute(block, len, f) XEF(compute, block, len, f)
+#define xef_fixerr(block, len, f) XEF(fixerr, block, len, f)
+
+#endif /* _XEF_H_ */

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/LICENSE
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/LICENSE
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/LICENSE

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/api.h
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/api.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/api.h

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/blnk.c
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/blnk.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.c

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/blnk.h
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/blnk.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.h

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/ct_util.c
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/ct_util.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.c

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/ct_util.h
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/ct_util.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.h

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/kem.c
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/kem.c

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/little_endian.h
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/little_endian.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/little_endian.h

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/nist_kem.h
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/nist_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/nist_kem.h

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_addsub.c
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_addsub.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.c

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_addsub.h
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_addsub.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.h

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_cca_kem.c
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_cca_kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.c

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_cca_kem.h
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_cca_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.h

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_cpa_pke.h
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_cpa_pke.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke.h

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_cpa_pke_n1.c
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_cpa_pke_n1.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_n1.c

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_cpa_pke_nd.c
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_cpa_pke_nd.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_nd.c

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_matmul.c
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_matmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.c

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_matmul.h
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_matmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.h

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_parameter_sets.h
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_parameter_sets.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_parameter_sets.h

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_ringmul.c
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_ringmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.c

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_ringmul.h
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_ringmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.h

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_xof.h
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_xof.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof.h

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_xof_shake.c
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_xof_shake.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_shake.c

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_xof_sneik.c
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/r5_xof_sneik.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_sneik.c

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/round5_variant_setting.h
@@ -1,0 +1,7 @@
+//  round5_variant_setting.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
+#define R5ND_3KEM_0d
+#define ROUND5_CCA_PKE
+#define BLNK2

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/sneik_f512_c99.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_f512_c99.c

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/sneik_param.h
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/sneik_param.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_param.h

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/xe2_c16.c
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/xe2_c16.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe2_c16.c

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/xe4_c64.c
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/xe4_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe4_c64.c

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/xe5_c64.c
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/xe5_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe5_c64.c

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/xef.h
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/xef.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xef.h

--- a/crypto_kem/r5nd-3kemcca-0d/opt/LICENSE
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/LICENSE
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/LICENSE

--- a/crypto_kem/r5nd-3kemcca-0d/opt/api.h
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/api.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/api.h

--- a/crypto_kem/r5nd-3kemcca-0d/opt/blnk.c
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/blnk.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.c

--- a/crypto_kem/r5nd-3kemcca-0d/opt/blnk.h
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/blnk.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.h

--- a/crypto_kem/r5nd-3kemcca-0d/opt/ct_util.c
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/ct_util.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.c

--- a/crypto_kem/r5nd-3kemcca-0d/opt/ct_util.h
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/ct_util.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.h

--- a/crypto_kem/r5nd-3kemcca-0d/opt/kem.c
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/kem.c

--- a/crypto_kem/r5nd-3kemcca-0d/opt/little_endian.h
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/little_endian.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/little_endian.h

--- a/crypto_kem/r5nd-3kemcca-0d/opt/nist_kem.h
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/nist_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/nist_kem.h

--- a/crypto_kem/r5nd-3kemcca-0d/opt/r5_addsub.c
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/r5_addsub.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.c

--- a/crypto_kem/r5nd-3kemcca-0d/opt/r5_addsub.h
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/r5_addsub.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.h

--- a/crypto_kem/r5nd-3kemcca-0d/opt/r5_cca_kem.c
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/r5_cca_kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.c

--- a/crypto_kem/r5nd-3kemcca-0d/opt/r5_cca_kem.h
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/r5_cca_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.h

--- a/crypto_kem/r5nd-3kemcca-0d/opt/r5_cpa_pke.h
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/r5_cpa_pke.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke.h

--- a/crypto_kem/r5nd-3kemcca-0d/opt/r5_cpa_pke_n1.c
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/r5_cpa_pke_n1.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_n1.c

--- a/crypto_kem/r5nd-3kemcca-0d/opt/r5_cpa_pke_nd.c
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/r5_cpa_pke_nd.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_nd.c

--- a/crypto_kem/r5nd-3kemcca-0d/opt/r5_matmul.c
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/r5_matmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.c

--- a/crypto_kem/r5nd-3kemcca-0d/opt/r5_matmul.h
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/r5_matmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.h

--- a/crypto_kem/r5nd-3kemcca-0d/opt/r5_parameter_sets.h
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/r5_parameter_sets.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_parameter_sets.h

--- a/crypto_kem/r5nd-3kemcca-0d/opt/r5_ringmul.c
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/r5_ringmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.c

--- a/crypto_kem/r5nd-3kemcca-0d/opt/r5_ringmul.h
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/r5_ringmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.h

--- a/crypto_kem/r5nd-3kemcca-0d/opt/r5_xof.h
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/r5_xof.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof.h

--- a/crypto_kem/r5nd-3kemcca-0d/opt/r5_xof_shake.c
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/r5_xof_shake.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_shake.c

--- a/crypto_kem/r5nd-3kemcca-0d/opt/r5_xof_sneik.c
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/r5_xof_sneik.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_sneik.c

--- a/crypto_kem/r5nd-3kemcca-0d/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/round5_variant_setting.h
@@ -1,0 +1,7 @@
+//  round5_variant_setting.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
+#define R5ND_3KEM_0d
+#define ROUND5_CCA_PKE
+

--- a/crypto_kem/r5nd-3kemcca-0d/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/sneik_f512_c99.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_f512_c99.c

--- a/crypto_kem/r5nd-3kemcca-0d/opt/sneik_param.h
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/sneik_param.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_param.h

--- a/crypto_kem/r5nd-3kemcca-0d/opt/xe2_c16.c
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/xe2_c16.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe2_c16.c

--- a/crypto_kem/r5nd-3kemcca-0d/opt/xe4_c64.c
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/xe4_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe4_c64.c

--- a/crypto_kem/r5nd-3kemcca-0d/opt/xe5_c64.c
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/xe5_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe5_c64.c

--- a/crypto_kem/r5nd-3kemcca-0d/opt/xef.h
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/xef.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xef.h

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/LICENSE
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/LICENSE
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/LICENSE

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/api.h
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/api.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/api.h

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/blnk.c
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/blnk.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.c

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/blnk.h
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/blnk.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.h

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/ct_util.c
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/ct_util.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.c

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/ct_util.h
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/ct_util.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.h

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/kem.c
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/kem.c

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/little_endian.h
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/little_endian.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/little_endian.h

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/nist_kem.h
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/nist_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/nist_kem.h

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_addsub.c
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_addsub.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.c

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_addsub.h
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_addsub.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.h

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_cca_kem.c
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_cca_kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.c

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_cca_kem.h
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_cca_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.h

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_cpa_pke.h
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_cpa_pke.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke.h

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_cpa_pke_n1.c
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_cpa_pke_n1.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_n1.c

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_cpa_pke_nd.c
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_cpa_pke_nd.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_nd.c

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_matmul.c
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_matmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.c

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_matmul.h
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_matmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.h

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_parameter_sets.h
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_parameter_sets.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_parameter_sets.h

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_ringmul.c
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_ringmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.c

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_ringmul.h
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_ringmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.h

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_xof.h
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_xof.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof.h

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_xof_shake.c
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_xof_shake.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_shake.c

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_xof_sneik.c
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/r5_xof_sneik.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_sneik.c

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/round5_variant_setting.h
@@ -1,0 +1,7 @@
+//  round5_variant_setting.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
+#define R5ND_3KEM_5d
+#define ROUND5_CCA_PKE
+#define BLNK2

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/sneik_f512_c99.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_f512_c99.c

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/sneik_param.h
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/sneik_param.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_param.h

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/xe2_c16.c
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/xe2_c16.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe2_c16.c

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/xe4_c64.c
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/xe4_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe4_c64.c

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/xe5_c64.c
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/xe5_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe5_c64.c

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/xef.h
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/xef.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xef.h

--- a/crypto_kem/r5nd-3kemcca-5d/opt/LICENSE
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/LICENSE
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/LICENSE

--- a/crypto_kem/r5nd-3kemcca-5d/opt/api.h
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/api.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/api.h

--- a/crypto_kem/r5nd-3kemcca-5d/opt/blnk.c
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/blnk.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.c

--- a/crypto_kem/r5nd-3kemcca-5d/opt/blnk.h
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/blnk.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.h

--- a/crypto_kem/r5nd-3kemcca-5d/opt/ct_util.c
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/ct_util.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.c

--- a/crypto_kem/r5nd-3kemcca-5d/opt/ct_util.h
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/ct_util.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.h

--- a/crypto_kem/r5nd-3kemcca-5d/opt/kem.c
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/kem.c

--- a/crypto_kem/r5nd-3kemcca-5d/opt/little_endian.h
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/little_endian.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/little_endian.h

--- a/crypto_kem/r5nd-3kemcca-5d/opt/nist_kem.h
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/nist_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/nist_kem.h

--- a/crypto_kem/r5nd-3kemcca-5d/opt/r5_addsub.c
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/r5_addsub.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.c

--- a/crypto_kem/r5nd-3kemcca-5d/opt/r5_addsub.h
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/r5_addsub.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.h

--- a/crypto_kem/r5nd-3kemcca-5d/opt/r5_cca_kem.c
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/r5_cca_kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.c

--- a/crypto_kem/r5nd-3kemcca-5d/opt/r5_cca_kem.h
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/r5_cca_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.h

--- a/crypto_kem/r5nd-3kemcca-5d/opt/r5_cpa_pke.h
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/r5_cpa_pke.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke.h

--- a/crypto_kem/r5nd-3kemcca-5d/opt/r5_cpa_pke_n1.c
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/r5_cpa_pke_n1.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_n1.c

--- a/crypto_kem/r5nd-3kemcca-5d/opt/r5_cpa_pke_nd.c
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/r5_cpa_pke_nd.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_nd.c

--- a/crypto_kem/r5nd-3kemcca-5d/opt/r5_matmul.c
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/r5_matmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.c

--- a/crypto_kem/r5nd-3kemcca-5d/opt/r5_matmul.h
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/r5_matmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.h

--- a/crypto_kem/r5nd-3kemcca-5d/opt/r5_parameter_sets.h
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/r5_parameter_sets.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_parameter_sets.h

--- a/crypto_kem/r5nd-3kemcca-5d/opt/r5_ringmul.c
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/r5_ringmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.c

--- a/crypto_kem/r5nd-3kemcca-5d/opt/r5_ringmul.h
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/r5_ringmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.h

--- a/crypto_kem/r5nd-3kemcca-5d/opt/r5_xof.h
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/r5_xof.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof.h

--- a/crypto_kem/r5nd-3kemcca-5d/opt/r5_xof_shake.c
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/r5_xof_shake.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_shake.c

--- a/crypto_kem/r5nd-3kemcca-5d/opt/r5_xof_sneik.c
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/r5_xof_sneik.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_sneik.c

--- a/crypto_kem/r5nd-3kemcca-5d/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/round5_variant_setting.h
@@ -1,0 +1,7 @@
+//  round5_variant_setting.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
+#define R5ND_3KEM_5d
+#define ROUND5_CCA_PKE
+

--- a/crypto_kem/r5nd-3kemcca-5d/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/sneik_f512_c99.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_f512_c99.c

--- a/crypto_kem/r5nd-3kemcca-5d/opt/sneik_param.h
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/sneik_param.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_param.h

--- a/crypto_kem/r5nd-3kemcca-5d/opt/xe2_c16.c
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/xe2_c16.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe2_c16.c

--- a/crypto_kem/r5nd-3kemcca-5d/opt/xe4_c64.c
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/xe4_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe4_c64.c

--- a/crypto_kem/r5nd-3kemcca-5d/opt/xe5_c64.c
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/xe5_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe5_c64.c

--- a/crypto_kem/r5nd-3kemcca-5d/opt/xef.h
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/xef.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xef.h

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/LICENSE
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/LICENSE
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/LICENSE

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/api.h
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/api.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/api.h

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/blnk.c
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/blnk.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.c

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/blnk.h
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/blnk.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.h

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/ct_util.c
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/ct_util.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.c

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/ct_util.h
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/ct_util.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.h

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/kem.c
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/kem.c

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/little_endian.h
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/little_endian.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/little_endian.h

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/nist_kem.h
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/nist_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/nist_kem.h

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_addsub.c
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_addsub.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.c

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_addsub.h
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_addsub.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.h

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_cca_kem.c
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_cca_kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.c

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_cca_kem.h
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_cca_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.h

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_cpa_pke.h
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_cpa_pke.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke.h

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_cpa_pke_n1.c
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_cpa_pke_n1.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_n1.c

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_cpa_pke_nd.c
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_cpa_pke_nd.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_nd.c

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_matmul.c
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_matmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.c

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_matmul.h
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_matmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.h

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_parameter_sets.h
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_parameter_sets.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_parameter_sets.h

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_ringmul.c
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_ringmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.c

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_ringmul.h
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_ringmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.h

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_xof.h
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_xof.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof.h

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_xof_shake.c
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_xof_shake.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_shake.c

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_xof_sneik.c
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/r5_xof_sneik.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_sneik.c

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/round5_variant_setting.h
@@ -1,0 +1,7 @@
+//  round5_variant_setting.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
+#define R5ND_5KEM_0d
+#define ROUND5_CCA_PKE
+#define BLNK2

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/sneik_f512_c99.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_f512_c99.c

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/sneik_param.h
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/sneik_param.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_param.h

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/xe2_c16.c
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/xe2_c16.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe2_c16.c

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/xe4_c64.c
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/xe4_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe4_c64.c

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/xe5_c64.c
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/xe5_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe5_c64.c

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/xef.h
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/xef.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xef.h

--- a/crypto_kem/r5nd-5kemcca-0d/opt/LICENSE
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/LICENSE
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/LICENSE

--- a/crypto_kem/r5nd-5kemcca-0d/opt/api.h
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/api.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/api.h

--- a/crypto_kem/r5nd-5kemcca-0d/opt/blnk.c
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/blnk.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.c

--- a/crypto_kem/r5nd-5kemcca-0d/opt/blnk.h
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/blnk.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.h

--- a/crypto_kem/r5nd-5kemcca-0d/opt/ct_util.c
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/ct_util.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.c

--- a/crypto_kem/r5nd-5kemcca-0d/opt/ct_util.h
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/ct_util.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.h

--- a/crypto_kem/r5nd-5kemcca-0d/opt/kem.c
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/kem.c

--- a/crypto_kem/r5nd-5kemcca-0d/opt/little_endian.h
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/little_endian.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/little_endian.h

--- a/crypto_kem/r5nd-5kemcca-0d/opt/nist_kem.h
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/nist_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/nist_kem.h

--- a/crypto_kem/r5nd-5kemcca-0d/opt/r5_addsub.c
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/r5_addsub.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.c

--- a/crypto_kem/r5nd-5kemcca-0d/opt/r5_addsub.h
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/r5_addsub.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.h

--- a/crypto_kem/r5nd-5kemcca-0d/opt/r5_cca_kem.c
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/r5_cca_kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.c

--- a/crypto_kem/r5nd-5kemcca-0d/opt/r5_cca_kem.h
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/r5_cca_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.h

--- a/crypto_kem/r5nd-5kemcca-0d/opt/r5_cpa_pke.h
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/r5_cpa_pke.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke.h

--- a/crypto_kem/r5nd-5kemcca-0d/opt/r5_cpa_pke_n1.c
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/r5_cpa_pke_n1.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_n1.c

--- a/crypto_kem/r5nd-5kemcca-0d/opt/r5_cpa_pke_nd.c
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/r5_cpa_pke_nd.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_nd.c

--- a/crypto_kem/r5nd-5kemcca-0d/opt/r5_matmul.c
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/r5_matmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.c

--- a/crypto_kem/r5nd-5kemcca-0d/opt/r5_matmul.h
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/r5_matmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.h

--- a/crypto_kem/r5nd-5kemcca-0d/opt/r5_parameter_sets.h
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/r5_parameter_sets.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_parameter_sets.h

--- a/crypto_kem/r5nd-5kemcca-0d/opt/r5_ringmul.c
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/r5_ringmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.c

--- a/crypto_kem/r5nd-5kemcca-0d/opt/r5_ringmul.h
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/r5_ringmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.h

--- a/crypto_kem/r5nd-5kemcca-0d/opt/r5_xof.h
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/r5_xof.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof.h

--- a/crypto_kem/r5nd-5kemcca-0d/opt/r5_xof_shake.c
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/r5_xof_shake.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_shake.c

--- a/crypto_kem/r5nd-5kemcca-0d/opt/r5_xof_sneik.c
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/r5_xof_sneik.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_sneik.c

--- a/crypto_kem/r5nd-5kemcca-0d/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/round5_variant_setting.h
@@ -1,0 +1,7 @@
+//  round5_variant_setting.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
+#define R5ND_5KEM_0d
+#define ROUND5_CCA_PKE
+

--- a/crypto_kem/r5nd-5kemcca-0d/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/sneik_f512_c99.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_f512_c99.c

--- a/crypto_kem/r5nd-5kemcca-0d/opt/sneik_param.h
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/sneik_param.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_param.h

--- a/crypto_kem/r5nd-5kemcca-0d/opt/xe2_c16.c
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/xe2_c16.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe2_c16.c

--- a/crypto_kem/r5nd-5kemcca-0d/opt/xe4_c64.c
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/xe4_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe4_c64.c

--- a/crypto_kem/r5nd-5kemcca-0d/opt/xe5_c64.c
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/xe5_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe5_c64.c

--- a/crypto_kem/r5nd-5kemcca-0d/opt/xef.h
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/xef.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xef.h

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/LICENSE
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/LICENSE
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/LICENSE

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/api.h
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/api.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/api.h

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/blnk.c
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/blnk.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.c

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/blnk.h
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/blnk.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.h

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/ct_util.c
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/ct_util.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.c

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/ct_util.h
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/ct_util.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.h

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/kem.c
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/kem.c

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/little_endian.h
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/little_endian.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/little_endian.h

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/nist_kem.h
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/nist_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/nist_kem.h

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_addsub.c
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_addsub.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.c

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_addsub.h
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_addsub.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.h

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_cca_kem.c
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_cca_kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.c

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_cca_kem.h
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_cca_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.h

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_cpa_pke.h
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_cpa_pke.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke.h

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_cpa_pke_n1.c
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_cpa_pke_n1.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_n1.c

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_cpa_pke_nd.c
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_cpa_pke_nd.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_nd.c

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_matmul.c
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_matmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.c

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_matmul.h
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_matmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.h

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_parameter_sets.h
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_parameter_sets.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_parameter_sets.h

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_ringmul.c
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_ringmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.c

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_ringmul.h
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_ringmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.h

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_xof.h
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_xof.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof.h

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_xof_shake.c
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_xof_shake.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_shake.c

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_xof_sneik.c
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/r5_xof_sneik.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_sneik.c

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/round5_variant_setting.h
@@ -1,0 +1,7 @@
+//  round5_variant_setting.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
+#define R5ND_5KEM_5d
+#define ROUND5_CCA_PKE
+#define BLNK2

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/sneik_f512_c99.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_f512_c99.c

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/sneik_param.h
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/sneik_param.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_param.h

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/xe2_c16.c
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/xe2_c16.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe2_c16.c

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/xe4_c64.c
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/xe4_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe4_c64.c

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/xe5_c64.c
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/xe5_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe5_c64.c

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/xef.h
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/xef.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xef.h

--- a/crypto_kem/r5nd-5kemcca-5d/opt/LICENSE
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/LICENSE
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/LICENSE

--- a/crypto_kem/r5nd-5kemcca-5d/opt/api.h
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/api.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/api.h

--- a/crypto_kem/r5nd-5kemcca-5d/opt/blnk.c
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/blnk.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.c

--- a/crypto_kem/r5nd-5kemcca-5d/opt/blnk.h
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/blnk.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/blnk.h

--- a/crypto_kem/r5nd-5kemcca-5d/opt/ct_util.c
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/ct_util.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.c

--- a/crypto_kem/r5nd-5kemcca-5d/opt/ct_util.h
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/ct_util.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/ct_util.h

--- a/crypto_kem/r5nd-5kemcca-5d/opt/kem.c
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/kem.c

--- a/crypto_kem/r5nd-5kemcca-5d/opt/little_endian.h
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/little_endian.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/little_endian.h

--- a/crypto_kem/r5nd-5kemcca-5d/opt/nist_kem.h
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/nist_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/nist_kem.h

--- a/crypto_kem/r5nd-5kemcca-5d/opt/r5_addsub.c
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/r5_addsub.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.c

--- a/crypto_kem/r5nd-5kemcca-5d/opt/r5_addsub.h
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/r5_addsub.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_addsub.h

--- a/crypto_kem/r5nd-5kemcca-5d/opt/r5_cca_kem.c
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/r5_cca_kem.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.c

--- a/crypto_kem/r5nd-5kemcca-5d/opt/r5_cca_kem.h
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/r5_cca_kem.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cca_kem.h

--- a/crypto_kem/r5nd-5kemcca-5d/opt/r5_cpa_pke.h
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/r5_cpa_pke.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke.h

--- a/crypto_kem/r5nd-5kemcca-5d/opt/r5_cpa_pke_n1.c
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/r5_cpa_pke_n1.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_n1.c

--- a/crypto_kem/r5nd-5kemcca-5d/opt/r5_cpa_pke_nd.c
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/r5_cpa_pke_nd.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_cpa_pke_nd.c

--- a/crypto_kem/r5nd-5kemcca-5d/opt/r5_matmul.c
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/r5_matmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.c

--- a/crypto_kem/r5nd-5kemcca-5d/opt/r5_matmul.h
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/r5_matmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_matmul.h

--- a/crypto_kem/r5nd-5kemcca-5d/opt/r5_parameter_sets.h
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/r5_parameter_sets.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_parameter_sets.h

--- a/crypto_kem/r5nd-5kemcca-5d/opt/r5_ringmul.c
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/r5_ringmul.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.c

--- a/crypto_kem/r5nd-5kemcca-5d/opt/r5_ringmul.h
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/r5_ringmul.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_ringmul.h

--- a/crypto_kem/r5nd-5kemcca-5d/opt/r5_xof.h
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/r5_xof.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof.h

--- a/crypto_kem/r5nd-5kemcca-5d/opt/r5_xof_shake.c
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/r5_xof_shake.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_shake.c

--- a/crypto_kem/r5nd-5kemcca-5d/opt/r5_xof_sneik.c
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/r5_xof_sneik.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/r5_xof_sneik.c

--- a/crypto_kem/r5nd-5kemcca-5d/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/round5_variant_setting.h
@@ -1,0 +1,7 @@
+//  round5_variant_setting.h
+//  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
+
+//  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
+#define R5ND_5KEM_5d
+#define ROUND5_CCA_PKE
+

--- a/crypto_kem/r5nd-5kemcca-5d/opt/sneik_f512_c99.c
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/sneik_f512_c99.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_f512_c99.c

--- a/crypto_kem/r5nd-5kemcca-5d/opt/sneik_param.h
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/sneik_param.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/sneik_param.h

--- a/crypto_kem/r5nd-5kemcca-5d/opt/xe2_c16.c
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/xe2_c16.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe2_c16.c

--- a/crypto_kem/r5nd-5kemcca-5d/opt/xe4_c64.c
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/xe4_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe4_c64.c

--- a/crypto_kem/r5nd-5kemcca-5d/opt/xe5_c64.c
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/xe5_c64.c
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xe5_c64.c

--- a/crypto_kem/r5nd-5kemcca-5d/opt/xef.h
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/xef.h
@@ -1,0 +1,1 @@
+../../r5nd-1kemcca-5d/opt/xef.h


### PR DESCRIPTION
These `opt` implementations are based on those in the [r5embed](https://github.com/r5embed/r5embed) repository.

Some changes:

- Remove assembly code. [pqm4](https://github.com/mupq/pqm4/) will also receive an `m4` implementation. This is just plain C.
- Remove code related to AVX2. Irrelevant for microcontrollers.
- The Round5 spec describes a CPA-secure KEM and a CCA-secure PKE. However, these implementations now only consider the underlying CCA-secure KEM of the latter. `CRYPTO_BYTES` and `CRYPTO_CIPHERTEXTBYTES` have been modified accordingly. Code related to the DEM and AES-GCM has been removed.
- Make it possible to say `#define BLNK2` in `round5_variant_setting.h` to select SNEIK instead of SHAKE.
- Adapt the XOF such that it uses our cSHAKE and SHAKE.
- Adapt the code such that it uses our `randombytes`.