### PR TITLE
Fix incremental sha512

### DIFF
--- a/common/sha2.c
+++ b/common/sha2.c
@@ -598,7 +598,7 @@ void sha512_inc_blocks(sha512ctx *state, const uint8_t *in, size_t inblocks) {
 
     uint64_t bytes = load_bigendian_64(state->ctx + 64);
 
-    crypto_hashblocks_sha256(state->ctx, in, 128 * inblocks);
+    crypto_hashblocks_sha512(state->ctx, in, 128 * inblocks);
     bytes += 128 * inblocks;
 
     store_bigendian_64(state->ctx + 64, bytes);


### PR DESCRIPTION
I found yet another bug in the incremental sha512. 

See https://github.com/PQClean/PQClean/pull/232
This is now also tested against NIST KATs now in PQClean. 

**Note that one of the schemes in mupq/pqm4 actually used this incremental API. So we don't have to rebenchmark anything**