### PR TITLE
Fix Python 3.6 compatibility and dubious use of printf

### DIFF
--- a/crypto_kem/stack.c
+++ b/crypto_kem/stack.c
@@ -26,7 +26,7 @@
 static void send_stack_usage(const char *s, unsigned int c) {
   char outs[120];
   hal_send_str(s);
-  sprintf(outs, "%u\n", c);
+  snprintf(outs, sizeof(outs), "%u\n", c);
   hal_send_str(outs);
 }
 

--- a/crypto_kem/testvectors-host.c
+++ b/crypto_kem/testvectors-host.c
@@ -32,11 +32,11 @@ static void printbytes(const unsigned char *x, unsigned long long xlen)
 {
   char outs[2*xlen+1];
   unsigned long long i;
-  for(i=0;i<xlen;i++)
+  for(i=0;i<xlen;i++) {
     sprintf(outs+2*i, "%02x", x[i]);
+  }
   outs[2*xlen] = 0;
-  printf(outs);
-  printf("\n");
+  puts(outs);
 }
 
 static uint32 seed[32] = { 3,1,4,1,5,9,2,6,5,3,5,8,9,7,9,3,2,3,8,4,6,2,6,4,3,3,8,3,2,7,9,5 } ;
@@ -118,7 +118,7 @@ int main(void)
     {
       if(key_a[j] != key_b[j])
       {
-        printf("ERROR\n");
+        puts("ERROR");
         return -1;
       }
     }

--- a/crypto_sign/stack.c
+++ b/crypto_sign/stack.c
@@ -27,7 +27,7 @@
 static void send_stack_usage(const char *s, unsigned int c) {
   char outs[120];
   hal_send_str(s);
-  sprintf(outs, "%u\n", c);
+  snprintf(outs, sizeof(outs), "%u\n", c);
   hal_send_str(outs);
 }
 

--- a/crypto_sign/testvectors-host.c
+++ b/crypto_sign/testvectors-host.c
@@ -31,13 +31,13 @@ typedef uint32_t uint32;
 
 static void printbytes(const unsigned char *x, unsigned long long xlen)
 {
-  char out[3];
+  char outs[2*xlen+1];
   unsigned long long i;
   for(i=0;i<xlen;i++) {
-    sprintf(out, "%02x", x[i]);
-    printf(out, 2);
+    sprintf(outs+2*i, "%02x", x[i]);
   }
-  printf("\n");
+  outs[2*xlen] = 0;
+  puts(outs);
 }
 
 static uint32 seed[32] = { 3,1,4,1,5,9,2,6,5,3,5,8,9,7,9,3,2,3,8,4,6,2,6,4,3,3,8,3,2,7,9,5 } ;
@@ -114,14 +114,14 @@ int main(void)
 
     if(r)
     {
-      printf("ERROR: signature verification failed\n");
+      puts("ERROR: signature verification failed");
       return -1;
     }
     for(k=0;k<i;k++)
     {
       if(sm[k]!=mi[k])
       {
-        printf("ERROR: message recovery failed\n");
+        puts("ERROR: message recovery failed");
         return -1;
       }
     }

--- a/mupq.py
+++ b/mupq.py
@@ -297,7 +297,7 @@ class SizeBenchmark(StackBenchmark):
                 'arm-none-eabi-size -t ' + glob,
                 shell=True,
                 stderr=subprocess.DEVNULL,
-                text=True)
+                universal_newlines=True)
         sizes = output.splitlines()[-1].split('\t')
         fsizes = (f'.text bytes:\n{sizes[0].strip()}\n'
                   f'.data bytes:\n{sizes[1].strip()}\n'


### PR DESCRIPTION
This fixes #24 and mupq/pqm4#111. It also makes all these different print functions slightly more similar.