### PR TITLE
Refactor number printing functions and avoid Xprintf functions

### DIFF
--- a/common/sendfn.h
+++ b/common/sendfn.h
@@ -1,0 +1,61 @@
+#ifndef SENDFN_H
+#define SENDFN_H
+
+#include "hal.h"
+
+__attribute__((unused))
+static void send_unsigned(const char *s, unsigned int c) {
+  int i = 0;
+  char outs[11] = {0};
+  if (c < 10) {
+    outs[0] = '0' + c;
+  } else {
+    for (i = 9; c != 0; c /= 10, i -= 1) {
+      unsigned d = c % 10;
+      outs[i] = '0' + d;
+    }
+    i += 1;
+  }
+  hal_send_str(s);
+  hal_send_str(outs + i);
+}
+
+__attribute__((unused))
+static void send_unsignedll(const char *s, unsigned long long c) {
+  int i = 0;
+  char outs[21] = {0};
+  if (c < 10) {
+    outs[0] = '0' + c;
+  } else {
+    i = 19;
+    while (c != 0) {
+      /* Method adapted from ""hackers delight":
+         Creates an approximation of q = (8/10) */
+      unsigned long long q = (c >> 1) + (c >> 2);
+      q = q + (q >> 4);
+      q = q + (q >> 8);
+      q = q + (q >> 16);
+      q = q + (q >> 32);
+      /* Now q = (1/10) */
+      q = q >> 3;
+      /* Since q contains an error due to the bits shifted out of the value, we
+         only use it to determine the remainder.  */
+      unsigned long long r = c - ((q << 3) + (q << 1));
+      c = q;
+      /* The remainder might be off by 10, so q may be off by 1 */
+      if (r > 9) {
+        c += 1;
+        r -= 10;
+      }
+      outs[i] = '0' + (unsigned) r;
+      i -= 1;
+    }
+    i += 1;
+  }
+  hal_send_str(s);
+  hal_send_str(outs + i);
+}
+
+
+#endif /* SENDFN_H */
+

--- a/crypto_kem/hashing.c
+++ b/crypto_kem/hashing.c
@@ -1,7 +1,7 @@
 #include "api.h"
 #include "hal.h"
+#include "sendfn.h"
 
-#include <stdio.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -21,13 +21,7 @@
 #define MUPQ_crypto_kem_enc NAMESPACE(crypto_kem_enc)
 #define MUPQ_crypto_kem_dec NAMESPACE(crypto_kem_dec)
 
-static void printcycles(const char *s, unsigned long long c)
-{
-  char outs[32];
-  hal_send_str(s);
-  snprintf(outs,sizeof(outs),"%llu\n",c);
-  hal_send_str(outs);
-}
+#define printcycles(S, U) send_unsignedll((S), (U))
 
 unsigned long long hash_cycles;
 

--- a/crypto_kem/speed.c
+++ b/crypto_kem/speed.c
@@ -1,7 +1,7 @@
 #include "api.h"
 #include "hal.h"
+#include "sendfn.h"
 
-#include <stdio.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -21,13 +21,7 @@
 #define MUPQ_crypto_kem_enc NAMESPACE(crypto_kem_enc)
 #define MUPQ_crypto_kem_dec NAMESPACE(crypto_kem_dec)
 
-static void printcycles(const char *s, unsigned long long c)
-{
-  char outs[32];
-  hal_send_str(s);
-  snprintf(outs,sizeof(outs),"%llu\n",c);
-  hal_send_str(outs);
-}
+#define printcycles(S, U) send_unsignedll((S), (U))
 
 int main(void)
 {

--- a/crypto_kem/stack.c
+++ b/crypto_kem/stack.c
@@ -1,8 +1,8 @@
 #include "api.h"
 #include "randombytes.h"
 #include "hal.h"
+#include "sendfn.h"
 
-#include <stdio.h>
 #include <string.h>
 
 #define MAX_SIZE 0x1B000
@@ -23,12 +23,7 @@
 #define MUPQ_crypto_kem_enc NAMESPACE(crypto_kem_enc)
 #define MUPQ_crypto_kem_dec NAMESPACE(crypto_kem_dec)
 
-static void send_stack_usage(const char *s, unsigned int c) {
-  char outs[120];
-  hal_send_str(s);
-  snprintf(outs, sizeof(outs), "%u\n", c);
-  hal_send_str(outs);
-}
+#define send_stack_usage(S, U) send_unsigned((S), (U))
 
 unsigned int canary_size = MAX_SIZE;
 volatile unsigned char *p;

--- a/crypto_sign/hashing.c
+++ b/crypto_sign/hashing.c
@@ -1,5 +1,6 @@
 #include "api.h"
 #include "hal.h"
+#include "sendfn.h"
 
 #include <stdio.h>
 #include <stdint.h>
@@ -23,13 +24,7 @@
 #define MUPQ_crypto_sign_signature NAMESPACE(crypto_sign_signature)
 #define MUPQ_crypto_sign_verify NAMESPACE(crypto_sign_verify)
 
-static void printcycles(const char *s, unsigned long long c)
-{
-  char outs[32];
-  hal_send_str(s);
-  snprintf(outs,sizeof(outs),"%llu\n",c);
-  hal_send_str(outs);
-}
+#define printcycles(S, U) send_unsignedll((S), (U))
 
 unsigned long long hash_cycles;
 

--- a/crypto_sign/speed.c
+++ b/crypto_sign/speed.c
@@ -1,5 +1,6 @@
 #include "api.h"
 #include "hal.h"
+#include "sendfn.h"
 
 #include <stdio.h>
 #include <stdint.h>
@@ -24,13 +25,7 @@
 #define MUPQ_crypto_sign_signature NAMESPACE(crypto_sign_signature)
 #define MUPQ_crypto_sign_verify NAMESPACE(crypto_sign_verify)
 
-static void printcycles(const char *s, unsigned long long c)
-{
-  char outs[32];
-  hal_send_str(s);
-  snprintf(outs,sizeof(outs),"%llu\n",c);
-  hal_send_str(outs);
-}
+#define printcycles(S, U) send_unsignedll((S), (U))
 
 int main(void)
 {

--- a/crypto_sign/stack.c
+++ b/crypto_sign/stack.c
@@ -1,6 +1,7 @@
 #include "api.h"
 #include "randombytes.h"
 #include "hal.h"
+#include "sendfn.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -24,12 +25,7 @@
 #define MUPQ_crypto_sign_signature NAMESPACE(crypto_sign_signature)
 #define MUPQ_crypto_sign_verify NAMESPACE(crypto_sign_verify)
 
-static void send_stack_usage(const char *s, unsigned int c) {
-  char outs[120];
-  hal_send_str(s);
-  snprintf(outs, sizeof(outs), "%u\n", c);
-  hal_send_str(outs);
-}
+#define send_stack_usage(S, U) send_unsigned((S), (U))
 
 unsigned int canary_size = MAX_SIZE;
 volatile unsigned char *p;


### PR DESCRIPTION
The refactoring removes a lot of identical duplicated code.

Avoiding the printf functions reduces code size *considerably*. This is may not
be necessary for platforms with larger flash sizes as in PQM4, however the
printf functions for RISC-V pull in a lot of code. There are the "nano" variants
of the libc, which are small enough. However, these don't support printing long
longs which we need for the cycle counts.

The code for unsigned long long printing uses a division by 10 trick from
hackers delight, since the compiler will otherwise use a generic 64-bit division
code, which is quite a bit larger.