### PR TITLE
Fix Round5 CCA KEM

### DIFF
--- a/crypto_kem/r5n1-1kemcca-0d-sneik/opt/round5_variant_setting.h
+++ b/crypto_kem/r5n1-1kemcca-0d-sneik/opt/round5_variant_setting.h
@@ -2,6 +2,5 @@
 //  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
 
 //  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
-#define R5N1_1KEM_0d
-#define ROUND5_CCA_PKE
+#define R5N1_1PKE_0d
 #define BLNK2

--- a/crypto_kem/r5n1-1kemcca-0d/opt/round5_variant_setting.h
+++ b/crypto_kem/r5n1-1kemcca-0d/opt/round5_variant_setting.h
@@ -2,6 +2,4 @@
 //  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
 
 //  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
-#define R5N1_1KEM_0d
-#define ROUND5_CCA_PKE
-
+#define R5N1_1PKE_0d

--- a/crypto_kem/r5n1-3kemcca-0d-sneik/opt/round5_variant_setting.h
+++ b/crypto_kem/r5n1-3kemcca-0d-sneik/opt/round5_variant_setting.h
@@ -2,7 +2,5 @@
 //  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
 
 //  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
-#define R5N1_3KEM_0d
-#define ROUND5_CCA_PKE
+#define R5N1_3PKE_0d
 #define BLNK2
-

--- a/crypto_kem/r5n1-3kemcca-0d/opt/round5_variant_setting.h
+++ b/crypto_kem/r5n1-3kemcca-0d/opt/round5_variant_setting.h
@@ -2,6 +2,4 @@
 //  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
 
 //  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
-#define R5N1_3KEM_0d
-#define ROUND5_CCA_PKE
-
+#define R5N1_3PKE_0d

--- a/crypto_kem/r5n1-5kemcca-0d-sneik/opt/round5_variant_setting.h
+++ b/crypto_kem/r5n1-5kemcca-0d-sneik/opt/round5_variant_setting.h
@@ -2,6 +2,5 @@
 //  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
 
 //  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
-#define R5N1_5KEM_0d
-#define ROUND5_CCA_PKE
+#define R5N1_5PKE_0d
 #define BLNK2

--- a/crypto_kem/r5n1-5kemcca-0d/opt/round5_variant_setting.h
+++ b/crypto_kem/r5n1-5kemcca-0d/opt/round5_variant_setting.h
@@ -2,6 +2,4 @@
 //  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
 
 //  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
-#define R5N1_5KEM_0d
-#define ROUND5_CCA_PKE
-
+#define R5N1_5PKE_0d

--- a/crypto_kem/r5nd-1kemcca-0d-sneik/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-1kemcca-0d-sneik/opt/round5_variant_setting.h
@@ -2,6 +2,5 @@
 //  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
 
 //  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
-#define R5ND_1KEM_0d
-#define ROUND5_CCA_PKE
+#define R5ND_1PKE_0d
 #define BLNK2

--- a/crypto_kem/r5nd-1kemcca-0d/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-1kemcca-0d/opt/round5_variant_setting.h
@@ -2,6 +2,4 @@
 //  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
 
 //  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
-#define R5ND_1KEM_0d
-#define ROUND5_CCA_PKE
-
+#define R5ND_1PKE_0d

--- a/crypto_kem/r5nd-1kemcca-5d-sneik/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-1kemcca-5d-sneik/opt/round5_variant_setting.h
@@ -2,7 +2,5 @@
 //  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
 
 //  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
-#define R5ND_1KEM_5d
-#define ROUND5_CCA_PKE
+#define R5ND_1PKE_5d
 #define BLNK2
-

--- a/crypto_kem/r5nd-1kemcca-5d/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-1kemcca-5d/opt/round5_variant_setting.h
@@ -2,6 +2,4 @@
 //  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
 
 //  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
-#define R5ND_1KEM_5d
-#define ROUND5_CCA_PKE
-
+#define R5ND_1PKE_5d

--- a/crypto_kem/r5nd-3kemcca-0d-sneik/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-3kemcca-0d-sneik/opt/round5_variant_setting.h
@@ -2,6 +2,5 @@
 //  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
 
 //  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
-#define R5ND_3KEM_0d
-#define ROUND5_CCA_PKE
+#define R5ND_3PKE_0d
 #define BLNK2

--- a/crypto_kem/r5nd-3kemcca-0d/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-3kemcca-0d/opt/round5_variant_setting.h
@@ -2,6 +2,4 @@
 //  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
 
 //  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
-#define R5ND_3KEM_0d
-#define ROUND5_CCA_PKE
-
+#define R5ND_3PKE_0d

--- a/crypto_kem/r5nd-3kemcca-5d-sneik/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-3kemcca-5d-sneik/opt/round5_variant_setting.h
@@ -2,6 +2,5 @@
 //  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
 
 //  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
-#define R5ND_3KEM_5d
-#define ROUND5_CCA_PKE
+#define R5ND_3PKE_5d
 #define BLNK2

--- a/crypto_kem/r5nd-3kemcca-5d/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-3kemcca-5d/opt/round5_variant_setting.h
@@ -2,6 +2,4 @@
 //  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
 
 //  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
-#define R5ND_3KEM_5d
-#define ROUND5_CCA_PKE
-
+#define R5ND_3PKE_5d

--- a/crypto_kem/r5nd-5kemcca-0d-sneik/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-5kemcca-0d-sneik/opt/round5_variant_setting.h
@@ -2,6 +2,5 @@
 //  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
 
 //  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
-#define R5ND_5KEM_0d
-#define ROUND5_CCA_PKE
+#define R5ND_5PKE_0d
 #define BLNK2

--- a/crypto_kem/r5nd-5kemcca-0d/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-5kemcca-0d/opt/round5_variant_setting.h
@@ -2,6 +2,4 @@
 //  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
 
 //  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
-#define R5ND_5KEM_0d
-#define ROUND5_CCA_PKE
-
+#define R5ND_5PKE_0d

--- a/crypto_kem/r5nd-5kemcca-5d-sneik/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-5kemcca-5d-sneik/opt/round5_variant_setting.h
@@ -2,6 +2,5 @@
 //  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
 
 //  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
-#define R5ND_5KEM_5d
-#define ROUND5_CCA_PKE
+#define R5ND_5PKE_5d
 #define BLNK2

--- a/crypto_kem/r5nd-5kemcca-5d/opt/round5_variant_setting.h
+++ b/crypto_kem/r5nd-5kemcca-5d/opt/round5_variant_setting.h
@@ -2,6 +2,4 @@
 //  Copyright (c) 2019, PQShield Ltd. and Koninklijke Philips N.V.
 
 //  This file can be used define the variant (e.g. just #define R5ND_1KEM_0d).
-#define R5ND_5KEM_5d
-#define ROUND5_CCA_PKE
-
+#define R5ND_5PKE_5d


### PR DESCRIPTION
In #36 it was noted that in our Round5 adaptions, we did not select the correct parameters for the underlying CCA-secure KEMs. This fixes that.