### PR TITLE
Skip AESNI and SSE implementations 

### DIFF
--- a/mupq.py
+++ b/mupq.py
@@ -115,7 +115,7 @@ class PlatformSettings(object):
                     if not os.path.isdir(scheme_path):
                         continue
                     for implementation_path in os.listdir(scheme_path):
-                        if implementation_path == "avx2":
+                        if implementation_path in ["avx2", "aesni", "sse"]:
                             continue
                         path = os.path.join(scheme_path,
                                             implementation_path)


### PR DESCRIPTION
https://github.com/PQClean/PQClean/pull/253 adds AESNI implementations of SPHINCS+.
https://github.com/PQClean/PQClean/pull/259 adds SSE implementations of McEliece.

Those obviously won't work on mupq targets, so I added those to the current
blacklist. In case more implementation types are added to pqclean in the future
we might want to switch a more clean filtering approach.