### PR TITLE
Add empty sha2_destroy functions

### DIFF
--- a/common/sha2.c
+++ b/common/sha2.c
@@ -586,6 +586,39 @@ void sha512_inc_clone_state(sha512ctx *stateout, const sha512ctx *statein) {
     memcpy(stateout, statein, sizeof(sha512ctx));
 }
 
+/* Destroy the hash state.
+ *
+ * Because this implementation is stack-based, this is a no-op
+ */
+void sha224_inc_destroy(sha224ctx *state) {
+    (void)state;
+}
+
+/* Destroy the hash state.
+ *
+ * Because this implementation is stack-based, this is a no-op
+ */
+void sha256_inc_destroy(sha256ctx *state) {
+    (void)state;
+}
+
+/* Destroy the hash state.
+ *
+ * Because this implementation is stack-based, this is a no-op
+ */
+void sha384_inc_destroy(sha384ctx *state) {
+    (void)state;
+}
+
+/* Destroy the hash state.
+ *
+ * Because this implementation is stack-based, this is a no-op
+ */
+void sha512_inc_destroy(sha512ctx *state) {
+    (void)state;
+}
+
+
 void sha256_inc_blocks(sha256ctx *state, const uint8_t *in, size_t inblocks) {
 #ifdef PROFILE_HASHING
     uint64_t t0 = hal_get_time();


### PR DESCRIPTION
https://github.com/PQClean/PQClean/commit/a655ec8a9d86eadd0cffe1f3b16f5e6e2ead7b94 added sha2_destory functions to the SPHINCS+ implementations.
As we have a stack-based implementations, these are no-ops.