### PR TITLE
outsource crypto_hashblocks_sha512

### DIFF
--- a/common/crypto_hashblocks_sha512.h
+++ b/common/crypto_hashblocks_sha512.h
@@ -1,0 +1,7 @@
+#ifndef CRYPTO_HASHBLOCKS_SHA512_H
+#define CRYPTO_HASHBLOCKS_SHA512_H
+
+int crypto_hashblocks_sha512(unsigned char *statebytes,const unsigned char *in,
+                      unsigned long long inlen);
+
+#endif

--- a/common/sha2.c
+++ b/common/sha2.c
@@ -7,6 +7,7 @@
 #include <string.h>
 
 #include "sha2.h"
+#include "crypto_hashblocks_sha512.h"
 
 #ifdef PROFILE_HASHING
 #include "hal.h"
@@ -55,7 +56,6 @@ static void store_bigendian_64(uint8_t *x, uint64_t u) {
 
 #define SHR(x, c) ((x) >> (c))
 #define ROTR_32(x, c) (((x) >> (c)) | ((x) << (32 - (c))))
-#define ROTR_64(x, c) (((x) >> (c)) | ((x) << (64 - (c))))
 
 #define Ch(x, y, z) (((x) & (y)) ^ (~(x) & (z)))
 #define Maj(x, y, z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
@@ -65,13 +65,7 @@ static void store_bigendian_64(uint8_t *x, uint64_t u) {
 #define sigma0_32(x) (ROTR_32(x, 7) ^ ROTR_32(x,18) ^ SHR(x, 3))
 #define sigma1_32(x) (ROTR_32(x,17) ^ ROTR_32(x,19) ^ SHR(x,10))
 
-#define Sigma0_64(x) (ROTR_64(x, 28) ^ ROTR_64(x, 34) ^ ROTR_64(x, 39))
-#define Sigma1_64(x) (ROTR_64(x, 14) ^ ROTR_64(x, 18) ^ ROTR_64(x, 41))
-#define sigma0_64(x) (ROTR_64(x, 1) ^ ROTR_64(x, 8) ^ SHR(x, 7))
-#define sigma1_64(x) (ROTR_64(x, 19) ^ ROTR_64(x, 61) ^ SHR(x, 6))
-
 #define M_32(w0, w14, w9, w1) w0 = sigma1_32(w14) + (w9) + sigma0_32(w1) + (w0);
-#define M_64(w0, w14, w9, w1) w0 = sigma1_64(w14) + (w9) + sigma0_64(w1) + (w0);
 
 #define EXPAND_32           \
     M_32(w0, w14, w9, w1)   \
@@ -91,39 +85,9 @@ static void store_bigendian_64(uint8_t *x, uint64_t u) {
     M_32(w14, w12, w7, w15) \
     M_32(w15, w13, w8, w0)
 
-#define EXPAND_64           \
-    M_64(w0, w14, w9, w1)   \
-    M_64(w1, w15, w10, w2)  \
-    M_64(w2, w0, w11, w3)   \
-    M_64(w3, w1, w12, w4)   \
-    M_64(w4, w2, w13, w5)   \
-    M_64(w5, w3, w14, w6)   \
-    M_64(w6, w4, w15, w7)   \
-    M_64(w7, w5, w0, w8)    \
-    M_64(w8, w6, w1, w9)    \
-    M_64(w9, w7, w2, w10)   \
-    M_64(w10, w8, w3, w11)  \
-    M_64(w11, w9, w4, w12)  \
-    M_64(w12, w10, w5, w13) \
-    M_64(w13, w11, w6, w14) \
-    M_64(w14, w12, w7, w15) \
-    M_64(w15, w13, w8, w0)
-
 #define F_32(w, k)                                   \
     T1 = h + Sigma1_32(e) + Ch(e, f, g) + (k) + (w); \
     T2 = Sigma0_32(a) + Maj(a, b, c);                \
-    h = g;                                           \
-    g = f;                                           \
-    f = e;                                           \
-    e = d + T1;                                      \
-    d = c;                                           \
-    c = b;                                           \
-    b = a;                                           \
-    a = T1 + T2;
-
-#define F_64(w, k)                                   \
-    T1 = h + Sigma1_64(e) + Ch(e, f, g) + (k) + (w); \
-    T2 = Sigma0_64(a) + Maj(a, b, c);                \
     h = g;                                           \
     g = f;                                           \
     f = e;                                           \
@@ -286,182 +250,6 @@ static size_t crypto_hashblocks_sha256(uint8_t *statebytes,
     store_bigendian_32(statebytes + 20, state[5]);
     store_bigendian_32(statebytes + 24, state[6]);
     store_bigendian_32(statebytes + 28, state[7]);
-
-    return inlen;
-}
-
-static size_t crypto_hashblocks_sha512(uint8_t *statebytes,
-                                       const uint8_t *in, size_t inlen) {
-    uint64_t state[8];
-    uint64_t a;
-    uint64_t b;
-    uint64_t c;
-    uint64_t d;
-    uint64_t e;
-    uint64_t f;
-    uint64_t g;
-    uint64_t h;
-    uint64_t T1;
-    uint64_t T2;
-
-    a = load_bigendian_64(statebytes + 0);
-    state[0] = a;
-    b = load_bigendian_64(statebytes + 8);
-    state[1] = b;
-    c = load_bigendian_64(statebytes + 16);
-    state[2] = c;
-    d = load_bigendian_64(statebytes + 24);
-    state[3] = d;
-    e = load_bigendian_64(statebytes + 32);
-    state[4] = e;
-    f = load_bigendian_64(statebytes + 40);
-    state[5] = f;
-    g = load_bigendian_64(statebytes + 48);
-    state[6] = g;
-    h = load_bigendian_64(statebytes + 56);
-    state[7] = h;
-
-    while (inlen >= 128) {
-        uint64_t w0 = load_bigendian_64(in + 0);
-        uint64_t w1 = load_bigendian_64(in + 8);
-        uint64_t w2 = load_bigendian_64(in + 16);
-        uint64_t w3 = load_bigendian_64(in + 24);
-        uint64_t w4 = load_bigendian_64(in + 32);
-        uint64_t w5 = load_bigendian_64(in + 40);
-        uint64_t w6 = load_bigendian_64(in + 48);
-        uint64_t w7 = load_bigendian_64(in + 56);
-        uint64_t w8 = load_bigendian_64(in + 64);
-        uint64_t w9 = load_bigendian_64(in + 72);
-        uint64_t w10 = load_bigendian_64(in + 80);
-        uint64_t w11 = load_bigendian_64(in + 88);
-        uint64_t w12 = load_bigendian_64(in + 96);
-        uint64_t w13 = load_bigendian_64(in + 104);
-        uint64_t w14 = load_bigendian_64(in + 112);
-        uint64_t w15 = load_bigendian_64(in + 120);
-
-        F_64(w0, 0x428a2f98d728ae22ULL)
-        F_64(w1, 0x7137449123ef65cdULL)
-        F_64(w2, 0xb5c0fbcfec4d3b2fULL)
-        F_64(w3, 0xe9b5dba58189dbbcULL)
-        F_64(w4, 0x3956c25bf348b538ULL)
-        F_64(w5, 0x59f111f1b605d019ULL)
-        F_64(w6, 0x923f82a4af194f9bULL)
-        F_64(w7, 0xab1c5ed5da6d8118ULL)
-        F_64(w8, 0xd807aa98a3030242ULL)
-        F_64(w9, 0x12835b0145706fbeULL)
-        F_64(w10, 0x243185be4ee4b28cULL)
-        F_64(w11, 0x550c7dc3d5ffb4e2ULL)
-        F_64(w12, 0x72be5d74f27b896fULL)
-        F_64(w13, 0x80deb1fe3b1696b1ULL)
-        F_64(w14, 0x9bdc06a725c71235ULL)
-        F_64(w15, 0xc19bf174cf692694ULL)
-
-        EXPAND_64
-
-        F_64(w0, 0xe49b69c19ef14ad2ULL)
-        F_64(w1, 0xefbe4786384f25e3ULL)
-        F_64(w2, 0x0fc19dc68b8cd5b5ULL)
-        F_64(w3, 0x240ca1cc77ac9c65ULL)
-        F_64(w4, 0x2de92c6f592b0275ULL)
-        F_64(w5, 0x4a7484aa6ea6e483ULL)
-        F_64(w6, 0x5cb0a9dcbd41fbd4ULL)
-        F_64(w7, 0x76f988da831153b5ULL)
-        F_64(w8, 0x983e5152ee66dfabULL)
-        F_64(w9, 0xa831c66d2db43210ULL)
-        F_64(w10, 0xb00327c898fb213fULL)
-        F_64(w11, 0xbf597fc7beef0ee4ULL)
-        F_64(w12, 0xc6e00bf33da88fc2ULL)
-        F_64(w13, 0xd5a79147930aa725ULL)
-        F_64(w14, 0x06ca6351e003826fULL)
-        F_64(w15, 0x142929670a0e6e70ULL)
-
-        EXPAND_64
-
-        F_64(w0, 0x27b70a8546d22ffcULL)
-        F_64(w1, 0x2e1b21385c26c926ULL)
-        F_64(w2, 0x4d2c6dfc5ac42aedULL)
-        F_64(w3, 0x53380d139d95b3dfULL)
-        F_64(w4, 0x650a73548baf63deULL)
-        F_64(w5, 0x766a0abb3c77b2a8ULL)
-        F_64(w6, 0x81c2c92e47edaee6ULL)
-        F_64(w7, 0x92722c851482353bULL)
-        F_64(w8, 0xa2bfe8a14cf10364ULL)
-        F_64(w9, 0xa81a664bbc423001ULL)
-        F_64(w10, 0xc24b8b70d0f89791ULL)
-        F_64(w11, 0xc76c51a30654be30ULL)
-        F_64(w12, 0xd192e819d6ef5218ULL)
-        F_64(w13, 0xd69906245565a910ULL)
-        F_64(w14, 0xf40e35855771202aULL)
-        F_64(w15, 0x106aa07032bbd1b8ULL)
-
-        EXPAND_64
-
-        F_64(w0, 0x19a4c116b8d2d0c8ULL)
-        F_64(w1, 0x1e376c085141ab53ULL)
-        F_64(w2, 0x2748774cdf8eeb99ULL)
-        F_64(w3, 0x34b0bcb5e19b48a8ULL)
-        F_64(w4, 0x391c0cb3c5c95a63ULL)
-        F_64(w5, 0x4ed8aa4ae3418acbULL)
-        F_64(w6, 0x5b9cca4f7763e373ULL)
-        F_64(w7, 0x682e6ff3d6b2b8a3ULL)
-        F_64(w8, 0x748f82ee5defb2fcULL)
-        F_64(w9, 0x78a5636f43172f60ULL)
-        F_64(w10, 0x84c87814a1f0ab72ULL)
-        F_64(w11, 0x8cc702081a6439ecULL)
-        F_64(w12, 0x90befffa23631e28ULL)
-        F_64(w13, 0xa4506cebde82bde9ULL)
-        F_64(w14, 0xbef9a3f7b2c67915ULL)
-        F_64(w15, 0xc67178f2e372532bULL)
-
-        EXPAND_64
-
-        F_64(w0, 0xca273eceea26619cULL)
-        F_64(w1, 0xd186b8c721c0c207ULL)
-        F_64(w2, 0xeada7dd6cde0eb1eULL)
-        F_64(w3, 0xf57d4f7fee6ed178ULL)
-        F_64(w4, 0x06f067aa72176fbaULL)
-        F_64(w5, 0x0a637dc5a2c898a6ULL)
-        F_64(w6, 0x113f9804bef90daeULL)
-        F_64(w7, 0x1b710b35131c471bULL)
-        F_64(w8, 0x28db77f523047d84ULL)
-        F_64(w9, 0x32caab7b40c72493ULL)
-        F_64(w10, 0x3c9ebe0a15c9bebcULL)
-        F_64(w11, 0x431d67c49c100d4cULL)
-        F_64(w12, 0x4cc5d4becb3e42b6ULL)
-        F_64(w13, 0x597f299cfc657e2aULL)
-        F_64(w14, 0x5fcb6fab3ad6faecULL)
-        F_64(w15, 0x6c44198c4a475817ULL)
-
-        a += state[0];
-        b += state[1];
-        c += state[2];
-        d += state[3];
-        e += state[4];
-        f += state[5];
-        g += state[6];
-        h += state[7];
-
-        state[0] = a;
-        state[1] = b;
-        state[2] = c;
-        state[3] = d;
-        state[4] = e;
-        state[5] = f;
-        state[6] = g;
-        state[7] = h;
-
-        in += 128;
-        inlen -= 128;
-    }
-
-    store_bigendian_64(statebytes + 0, state[0]);
-    store_bigendian_64(statebytes + 8, state[1]);
-    store_bigendian_64(statebytes + 16, state[2]);
-    store_bigendian_64(statebytes + 24, state[3]);
-    store_bigendian_64(statebytes + 32, state[4]);
-    store_bigendian_64(statebytes + 40, state[5]);
-    store_bigendian_64(statebytes + 48, state[6]);
-    store_bigendian_64(statebytes + 56, state[7]);
 
     return inlen;
 }


### PR DESCRIPTION
[supercop20200409](https://bench.cr.yp.to/supercop/supercop-20200409.tar.xz) shipped a  fast m4 implementation of `crypto_hashblocks_sha512` which is used by a number of schemes in [pqm4](https://github.com/mupq/pqm4). This PR makes the necessary changes in [mupq](https://github.com/mupq/mupq) to allow the sub-projects to provide their own specialized implementation of `crypto_hashblocks_sha512`. 
