### PR TITLE
Remove printbytes from randombytes

### DIFF
--- a/crypto_kem/testvectors-host.c
+++ b/crypto_kem/testvectors-host.c
@@ -68,8 +68,6 @@ static void surf(void)
 
 int randombytes(uint8_t *x, size_t xlen)
 {
-  unsigned long long bak = xlen;
-  unsigned char *xbak = x;
 
   while (xlen > 0) {
     if (!outleft) {
@@ -81,7 +79,6 @@ int randombytes(uint8_t *x, size_t xlen)
     ++x;
     --xlen;
   }
-  printbytes(xbak, bak);
 
   return 0;
 }

--- a/crypto_kem/testvectors.c
+++ b/crypto_kem/testvectors.c
@@ -67,8 +67,6 @@ static void surf(void)
 
 int randombytes(uint8_t *x, size_t xlen)
 {
-  unsigned long long bak = xlen;
-  unsigned char *xbak = x;
 
   while (xlen > 0) {
     if (!outleft) {
@@ -80,7 +78,6 @@ int randombytes(uint8_t *x, size_t xlen)
     ++x;
     --xlen;
   }
-  printbytes(xbak, bak);
 
   return 0;
 }


### PR DESCRIPTION
For NTRUPrime, we ran into the problem that the reference implementation samples randomness in rather small 4-byte chunks, while the optimized implementation uses larger chunks. 
The resulting testvectors are exactly the same, but pqm4/mupq still complained because 
`randombytes(x, 1); randombytes(x, 1);` results in printing `AB\nCD\n` while `randombytes(x, 2);` results in printing  `ABCD\n`. 

I removed the `printbytes()` from the `randombytes()` in this PR as I cannot think of any purpose this serves other than debugging. Note that for signatures, we somehow never had a `printbytes()` in there. This difference seems to date back to the very first days of pqm4. 