### PR TITLE
More robust result parsing

### DIFF
--- a/crypto_kem/hashing.c
+++ b/crypto_kem/hashing.c
@@ -50,16 +50,16 @@ int main(void)
   t0 = hal_get_time();
   MUPQ_crypto_kem_enc(ct, key_a, pk);
   t1 = hal_get_time();
-  printcycles("encaps cycles: ", t1-t0);
-  printcycles("encaps hash cycles: ", hash_cycles);
+  printcycles("encaps cycles:", t1-t0);
+  printcycles("encaps hash cycles:", hash_cycles);
 
   // Decapsulation
   hash_cycles = 0;
   t0 = hal_get_time();
   MUPQ_crypto_kem_dec(key_b, ct, sk);
   t1 = hal_get_time();
-  printcycles("decaps cycles: ", t1-t0);
-  printcycles("decaps hash cycles: ", hash_cycles);
+  printcycles("decaps cycles:", t1-t0);
+  printcycles("decaps hash cycles:", hash_cycles);
 
   if (memcmp(key_a, key_b, MUPQ_CRYPTO_BYTES)) {
     hal_send_str("ERROR KEYS\n");

--- a/crypto_kem/speed.c
+++ b/crypto_kem/speed.c
@@ -45,13 +45,13 @@ int main(void)
   t0 = hal_get_time();
   MUPQ_crypto_kem_enc(ct, key_a, pk);
   t1 = hal_get_time();
-  printcycles("encaps cycles: ", t1-t0);
+  printcycles("encaps cycles:", t1-t0);
 
   // Decapsulation
   t0 = hal_get_time();
   MUPQ_crypto_kem_dec(key_b, ct, sk);
   t1 = hal_get_time();
-  printcycles("decaps cycles: ", t1-t0);
+  printcycles("decaps cycles:", t1-t0);
 
   if (memcmp(key_a, key_b, MUPQ_CRYPTO_BYTES)) {
     hal_send_str("ERROR KEYS\n");

--- a/crypto_kem/stack.c
+++ b/crypto_kem/stack.c
@@ -74,9 +74,9 @@ static int test_keys(void) {
   if (memcmp(key_a, key_b, MUPQ_CRYPTO_BYTES)){
     return -1;
   } else {
-    send_stack_usage("key gen stack usage", stack_key_gen);
-    send_stack_usage("encaps stack usage", stack_encaps);
-    send_stack_usage("decaps stack usage", stack_decaps);
+    send_stack_usage("keypair stack usage:", stack_key_gen);
+    send_stack_usage("encaps stack usage:", stack_encaps);
+    send_stack_usage("decaps stack usage:", stack_decaps);
     hal_send_str("OK KEYS\n");
     return 0;
   }

--- a/crypto_sign/hashing.c
+++ b/crypto_sign/hashing.c
@@ -53,16 +53,16 @@ int main(void)
   t0 = hal_get_time();
   MUPQ_crypto_sign(sm, &smlen, sm, MLEN, sk);
   t1 = hal_get_time();
-  printcycles("sign cycles: ", t1-t0);
-  printcycles("sign hash cycles: ", hash_cycles);
+  printcycles("sign cycles:", t1-t0);
+  printcycles("sign hash cycles:", hash_cycles);
 
   // Verification
   hash_cycles = 0;
   t0 = hal_get_time();
   MUPQ_crypto_sign_open(sm, &smlen, sm, smlen, pk);
   t1 = hal_get_time();
-  printcycles("verify cycles: ", t1-t0);
-  printcycles("verify hash cycles: ", hash_cycles);
+  printcycles("verify cycles:", t1-t0);
+  printcycles("verify hash cycles:", hash_cycles);
 
   hal_send_str("#");
   while(1);

--- a/crypto_sign/speed.c
+++ b/crypto_sign/speed.c
@@ -49,13 +49,13 @@ int main(void)
   t0 = hal_get_time();
   MUPQ_crypto_sign(sm, &smlen, sm, MLEN, sk);
   t1 = hal_get_time();
-  printcycles("sign cycles: ", t1-t0);
+  printcycles("sign cycles:", t1-t0);
 
   // Verification
   t0 = hal_get_time();
   MUPQ_crypto_sign_open(sm, &smlen, sm, smlen, pk);
   t1 = hal_get_time();
-  printcycles("verify cycles: ", t1-t0);
+  printcycles("verify cycles:", t1-t0);
 
   hal_send_str("#");
   while(1);

--- a/crypto_sign/stack.c
+++ b/crypto_sign/stack.c
@@ -82,9 +82,9 @@ static int test_sign(void) {
   if (rc) {
     return -1;
   } else {
-    send_stack_usage("crypto_sign_keypair stack usage", stack_key_gen);
-    send_stack_usage("crypto_sign stack usage", stack_sign);
-    send_stack_usage("crypto_sign_open stack usage", stack_verify);
+    send_stack_usage("keypair stack usage:", stack_key_gen);
+    send_stack_usage("sign stack usage:", stack_sign);
+    send_stack_usage("verify stack usage:", stack_verify);
     hal_send_str("Signature valid!\n");
     return 0;
   }


### PR DESCRIPTION
When doing the new benchmarks, I sometimes ran into the problem that the
speed benchmarks contained something like

keypair cycles:
6639120105
keypair cycles:
6639120105
sign cycles:
103762136231
verify cycles:
154024957

So for what ever reason, the board was reset after the first key gen was done.
Our parsing script didn't really handle this well as it was based on line
numbers. I made that more robust in this patch.

I also made it a bit more consistent across benchmarks.