### PR TITLE
Make testvectors less dependent on PRNG state

### DIFF
--- a/crypto_sign/testvectors-host.c
+++ b/crypto_sign/testvectors-host.c
@@ -67,6 +67,11 @@ static void surf(void)
   }
 }
 
+static void setstate(int i) {
+	memset(in, i, sizeof(in));
+	outleft = 0;
+}
+
 int randombytes(uint8_t *x, size_t xlen)
 {
   while (xlen > 0) {
@@ -98,6 +103,7 @@ int main(void)
 
   for(i=0; i<MAXMLEN; i=(i==0)?i+1:i<<1)
   {
+    setstate(i);
     randombytes(mi,i);
 
     MUPQ_crypto_sign_keypair(pk, sk);

--- a/crypto_sign/testvectors.c
+++ b/crypto_sign/testvectors.c
@@ -67,6 +67,11 @@ static void surf(void)
   }
 }
 
+static void setstate(int i) {
+	memset(in, i, sizeof(in));
+	outleft = 0;
+}
+
 int randombytes(uint8_t *x, size_t xlen)
 {
   while (xlen > 0) {
@@ -101,6 +106,7 @@ int main(void)
 
   for(i=0; i<MAXMLEN; i=(i==0)?i+1:i<<1)
   {
+    setstate(i);
     randombytes(mi,i);
 
     MUPQ_crypto_sign_keypair(pk, sk);


### PR DESCRIPTION
Hi,

We are working in side-channel protected implementations of signature schemes, which require different amounts of randomness depending on the order of countermeasures. This difference makes the testvector binaries fail because consecutive inputs and key pairs will be different between host and target even if implementations are compatible, due to different PRNG states between the two. As a result, debugging gets a little more complicated and frustrating.

This PR fixes the PRNG state at the beginning of each iteration. Probably not in the best way possible, but I'm sending it to start a conversation around the issue. :)