### PR TITLE
Absorption and squeezing of Keccak take less time and space.

### DIFF
--- a/common/fips202.c
+++ b/common/fips202.c
@@ -38,9 +38,7 @@ static void keccak_absorb(uint64_t *s,
     const uint8_t *m, size_t mlen,
     uint8_t p)
 {
-  size_t i;
-  uint8_t t[200];
-
+  uint8_t t;
   while (mlen >= r)
   {
     KeccakF1600_StateXORBytes(s, m, 0, r);
@@ -49,14 +47,11 @@ static void keccak_absorb(uint64_t *s,
     m += r;
   }
 
-  for (i = 0; i < r; ++i)
-    t[i] = 0;
-  for (i = 0; i < mlen; ++i)
-    t[i] = m[i];
-  t[i] = p;
-  t[r - 1] |= 128;
-
-  KeccakF1600_StateXORBytes(s, t, 0, r);
+  KeccakF1600_StateXORBytes(s, m, 0, mlen);
+  t = p;
+  KeccakF1600_StateXORBytes(s, &t, mlen+1, 1);
+  t = 128;
+  KeccakF1600_StateXORBytes(s, &t, r-1, 1);
 }
 
 
@@ -150,14 +145,10 @@ static void keccak_inc_absorb(uint64_t *s_inc, uint32_t r, const uint8_t *m,
 static void keccak_inc_finalize(uint64_t *s_inc, uint32_t r, uint8_t p) {
     /* After keccak_inc_absorb, we are guaranteed that s_inc[25] < r,
        so we can always use one more byte for p in the current state. */
-    size_t i;
-    uint8_t t[200];
-    for (i = 0; i < r; ++i)
-      t[i] = 0;
-    t[s_inc[25]] = p;
-    t[r - 1] |= 128;
-
-    KeccakF1600_StateXORBytes(s_inc, t, 0, r);
+    uint8_t t = p;
+    KeccakF1600_StateXORBytes(s_inc, &t, s_inc[25], 1);
+    t = 128;
+    KeccakF1600_StateXORBytes(s_inc, &t, r-1, 1);
     s_inc[25] = 0;
 }
 


### PR DESCRIPTION
Hi,

This small patch simplifies functions `keccak_absorb()` and `keccak_inc_finalize()` to not require a full temporary state vector to perform updates, while respecting the state representation imposed by `KeccakF1600_StateXORBytes()`. I verified that the changes worked on both the Desktop and STM32F4 builds by checking the test vectors of an in-progress implementation of Picnic3, which is quite heavy on hashing.

I could not test and benchmark across all `pqm4` algorithms, but Picnic3 got > 5% faster with these small changes in comparison to our previous code using XKCP. I cannot see how the changes can cause any performance regression, since the previous code updates the state with plenty of 0s.

Thank you!