### PR TITLE
Potential fix to the kyber512 issue.

### DIFF
--- a/common/fips202.c
+++ b/common/fips202.c
@@ -47,7 +47,7 @@ static void keccak_absorb(uint64_t *s,
   }
 
   if(mlen > 0){
-    KeccakF1600_StateXORBytes(s, m, mlen, r);
+    KeccakF1600_StateXORBytes(s, m, 0, mlen);
   }
 
   if(mlen == r-1){


### PR DESCRIPTION
Considering that the loop consumes full blocks, line 50 should just update the state with the remaining bytes.