### PR TITLE
Stack size cap

### DIFF
--- a/crypto_kem/stack.c
+++ b/crypto_kem/stack.c
@@ -95,10 +95,13 @@ int main(void) {
   hal_send_str("==========================");
   canary_size = STACK_SIZE_INCR;
   while(test_keys()){
-    canary_size += STACK_SIZE_INCR;
-    if(canary_size >= MAX_STACK_SIZE) {
+    if(canary_size == MAX_STACK_SIZE) {
       hal_send_str("failed to measure stack usage.\n");
       break;
+    }
+    canary_size += STACK_SIZE_INCR;
+    if(canary_size >= MAX_STACK_SIZE) {
+      canary_size = MAX_STACK_SIZE;
     }
   }
   // marker for automated benchmarks

--- a/crypto_sign/stack.c
+++ b/crypto_sign/stack.c
@@ -103,10 +103,13 @@ int main(void) {
   hal_send_str("==========================");
   canary_size = STACK_SIZE_INCR;
   while(test_sign()){
-    canary_size += STACK_SIZE_INCR;
-    if(canary_size >= MAX_STACK_SIZE) {
+    if(canary_size == MAX_STACK_SIZE) {
       hal_send_str("failed to measure stack usage.\n");
       break;
+    }
+    canary_size += STACK_SIZE_INCR;
+    if(canary_size >= MAX_STACK_SIZE) {
+      canary_size = MAX_STACK_SIZE;
     }
   }
 


### PR DESCRIPTION
In some rare cases, the incremental step of the `canary_size` will overflow the `MAX_STACK_SIZE`, even though the scheme still fits. This will do at least one additional run with the absolute maximum stack size.