### PR TITLE
Fix testvectors when cc=clang

### DIFF
--- a/crypto_kem/hashing.c
+++ b/crypto_kem/hashing.c
@@ -6,7 +6,7 @@
 #include <string.h>
 
 // https://stackoverflow.com/a/1489985/1711232
-#define PASTER(x, y) x####y
+#define PASTER(x, y) x##y
 #define EVALUATOR(x, y) PASTER(x, y)
 #define NAMESPACE(fun) EVALUATOR(MUPQ_NAMESPACE, fun)
 

--- a/crypto_kem/speed.c
+++ b/crypto_kem/speed.c
@@ -6,7 +6,7 @@
 #include <string.h>
 
 // https://stackoverflow.com/a/1489985/1711232
-#define PASTER(x, y) x####y
+#define PASTER(x, y) x##y
 #define EVALUATOR(x, y) PASTER(x, y)
 #define NAMESPACE(fun) EVALUATOR(MUPQ_NAMESPACE, fun)
 

--- a/crypto_kem/stack.c
+++ b/crypto_kem/stack.c
@@ -14,7 +14,7 @@
 #endif
 
 // https://stackoverflow.com/a/1489985/1711232
-#define PASTER(x, y) x####y
+#define PASTER(x, y) x##y
 #define EVALUATOR(x, y) PASTER(x, y)
 #define NAMESPACE(fun) EVALUATOR(MUPQ_NAMESPACE, fun)
 

--- a/crypto_kem/test.c
+++ b/crypto_kem/test.c
@@ -7,7 +7,7 @@
 #define NTESTS 10
 
 // https://stackoverflow.com/a/1489985/1711232
-#define PASTER(x, y) x####y
+#define PASTER(x, y) x##y
 #define EVALUATOR(x, y) PASTER(x, y)
 #define NAMESPACE(fun) EVALUATOR(MUPQ_NAMESPACE, fun)
 

--- a/crypto_kem/testvectors-host.c
+++ b/crypto_kem/testvectors-host.c
@@ -11,7 +11,7 @@
 #define NTESTS 2
 
 // https://stackoverflow.com/a/1489985/1711232
-#define PASTER(x, y) x####y
+#define PASTER(x, y) x##y
 #define EVALUATOR(x, y) PASTER(x, y)
 #define NAMESPACE(fun) EVALUATOR(MUPQ_NAMESPACE, fun)
 

--- a/crypto_kem/testvectors.c
+++ b/crypto_kem/testvectors.c
@@ -11,7 +11,7 @@
 
 #define NTESTS 2
 // https://stackoverflow.com/a/1489985/1711232
-#define PASTER(x, y) x####y
+#define PASTER(x, y) x##y
 #define EVALUATOR(x, y) PASTER(x, y)
 #define NAMESPACE(fun) EVALUATOR(MUPQ_NAMESPACE, fun)
 

--- a/crypto_sign/hashing.c
+++ b/crypto_sign/hashing.c
@@ -8,7 +8,7 @@
 
 #define MLEN 59
 // https://stackoverflow.com/a/1489985/1711232
-#define PASTER(x, y) x####y
+#define PASTER(x, y) x##y
 #define EVALUATOR(x, y) PASTER(x, y)
 #define NAMESPACE(fun) EVALUATOR(MUPQ_NAMESPACE, fun)
 

--- a/crypto_sign/speed.c
+++ b/crypto_sign/speed.c
@@ -9,7 +9,7 @@
 #define MLEN 59
 
 // https://stackoverflow.com/a/1489985/1711232
-#define PASTER(x, y) x####y
+#define PASTER(x, y) x##y
 #define EVALUATOR(x, y) PASTER(x, y)
 #define NAMESPACE(fun) EVALUATOR(MUPQ_NAMESPACE, fun)
 

--- a/crypto_sign/stack.c
+++ b/crypto_sign/stack.c
@@ -16,7 +16,7 @@
 
 #define MLEN 32
 // https://stackoverflow.com/a/1489985/1711232
-#define PASTER(x, y) x####y
+#define PASTER(x, y) x##y
 #define EVALUATOR(x, y) PASTER(x, y)
 #define NAMESPACE(fun) EVALUATOR(MUPQ_NAMESPACE, fun)
 

--- a/crypto_sign/test.c
+++ b/crypto_sign/test.c
@@ -8,7 +8,7 @@
 #define MLEN 32
 
 // https://stackoverflow.com/a/1489985/1711232
-#define PASTER(x, y) x####y
+#define PASTER(x, y) x##y
 #define EVALUATOR(x, y) PASTER(x, y)
 #define NAMESPACE(fun) EVALUATOR(MUPQ_NAMESPACE, fun)
 

--- a/crypto_sign/testvectors-host.c
+++ b/crypto_sign/testvectors-host.c
@@ -11,7 +11,7 @@
 #define MAXMLEN 2048
 
 // https://stackoverflow.com/a/1489985/1711232
-#define PASTER(x, y) x####y
+#define PASTER(x, y) x##y
 #define EVALUATOR(x, y) PASTER(x, y)
 #define NAMESPACE(fun) EVALUATOR(MUPQ_NAMESPACE, fun)
 

--- a/crypto_sign/testvectors.c
+++ b/crypto_sign/testvectors.c
@@ -12,7 +12,7 @@
 #define MAXMLEN 2048
 
 // https://stackoverflow.com/a/1489985/1711232
-#define PASTER(x, y) x####y
+#define PASTER(x, y) x##y
 #define EVALUATOR(x, y) PASTER(x, y)
 #define NAMESPACE(fun) EVALUATOR(MUPQ_NAMESPACE, fun)
 


### PR DESCRIPTION
Clang complains about x####y -- it should be x##y. 

The error only occured in `testvectors-host.c`, but I fixed it in all the sources. 