### PR TITLE
Add MAYO

### DIFF
--- a/crypto_sign/mayo1/ref/LICENSE
+++ b/crypto_sign/mayo1/ref/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crypto_sign/mayo1/ref/aes_ctr.c
+++ b/crypto_sign/mayo1/ref/aes_ctr.c
@@ -1,0 +1,13 @@
+#include "aes_ctr.h"
+#include "aes-publicinputs.h"
+
+
+int AES_128_CTR(unsigned char *output, size_t outputByteLen,
+                const unsigned char *input, size_t inputByteLen){
+    (void) inputByteLen;
+    aes128ctx_publicinputs ctx;
+    unsigned char iv[12] = {0};
+    aes128_ctr_keyexp_publicinputs(&ctx, input);
+    aes128_ctr_publicinputs(output, outputByteLen, iv, &ctx);
+    return outputByteLen;
+}

--- a/crypto_sign/mayo1/ref/aes_ctr.h
+++ b/crypto_sign/mayo1/ref/aes_ctr.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef AESCTR_H
+#define AESCTR_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+void AES_256_ECB(const uint8_t *input, const uint8_t *key, uint8_t *output);
+#define AES_ECB_encrypt AES_256_ECB
+
+#ifdef ENABLE_AESNI
+int AES_128_CTR_NI(unsigned char *output, size_t outputByteLen,
+                   const unsigned char *input, size_t inputByteLen);
+int AES_128_CTR_4R_NI(unsigned char *output, size_t outputByteLen,
+                      const unsigned char *input, size_t inputByteLen);
+#define AES_128_CTR AES_128_CTR_NI
+#else
+int AES_128_CTR(unsigned char *output, size_t outputByteLen,
+                const unsigned char *input, size_t inputByteLen);
+#endif
+
+#endif

--- a/crypto_sign/mayo1/ref/api.c
+++ b/crypto_sign/mayo1/ref/api.c
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <api.h>
+#include <mayo.h>
+
+int
+crypto_sign_keypair(unsigned char *pk, unsigned char *sk) {
+    return mayo_keypair(&MAYO_1, pk, sk);
+}
+
+#ifndef PQM4
+int
+crypto_sign(unsigned char *sm, unsigned long long *smlen,
+            const unsigned char *m, unsigned long long mlen,
+            const unsigned char *sk) {
+    return mayo_sign(&MAYO_1, sm, smlen, m, mlen, sk);
+}
+
+int
+crypto_sign_open(unsigned char *m, unsigned long long *mlen,
+                 const unsigned char *sm, unsigned long long smlen,
+                 const unsigned char *pk) {
+    return mayo_open(&MAYO_1, m, mlen, sm, smlen, pk);
+}
+
+
+#else
+int
+crypto_sign(unsigned char *sm, size_t *smlen,
+            const unsigned char *m, size_t mlen,
+            const unsigned char *sk) {
+
+    unsigned long long smlen_ll;
+    int rc = mayo_sign(&MAYO_1, sm, &smlen_ll, m, mlen, sk);
+    *smlen = smlen_ll;
+    return rc;
+}
+
+int
+crypto_sign_open(unsigned char *m, size_t *mlen,
+                 const unsigned char *sm, size_t smlen,
+                 const unsigned char *pk) {
+    unsigned long long mlen_ll;
+    int rc = mayo_open(&MAYO_1, m, &mlen_ll, sm, smlen, pk);
+    *mlen = mlen_ll;
+    return rc;
+}
+#endif

--- a/crypto_sign/mayo1/ref/api.h
+++ b/crypto_sign/mayo1/ref/api.h
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef api_h
+#define api_h
+
+#define CRYPTO_SECRETKEYBYTES 24
+#define CRYPTO_PUBLICKEYBYTES 1168
+#define CRYPTO_BYTES 321
+
+#define CRYPTO_ALGNAME "MAYO_1"
+#ifndef PQM4
+#define PQM4
+#endif
+
+int
+crypto_sign_keypair(unsigned char *pk, unsigned char *sk);
+
+
+
+#ifndef PQM4
+int
+crypto_sign(unsigned char *sm, unsigned long long *smlen,
+            const unsigned char *m, unsigned long long mlen,
+            const unsigned char *sk);
+
+int
+crypto_sign_open(unsigned char *m, unsigned long long *mlen,
+                 const unsigned char *sm, unsigned long long smlen,
+                 const unsigned char *pk);
+
+#else
+#include <stddef.h>
+
+int
+crypto_sign(unsigned char *sm, size_t *smlen,
+            const unsigned char *m, size_t mlen,
+            const unsigned char *sk);
+
+int
+crypto_sign_open(unsigned char *m, size_t *mlen,
+                 const unsigned char *sm, size_t smlen,
+                 const unsigned char *pk);
+#endif
+
+#endif /* api_h */

--- a/crypto_sign/mayo1/ref/bitsliced_arithmetic.c
+++ b/crypto_sign/mayo1/ref/bitsliced_arithmetic.c
@@ -1,0 +1,644 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "bitsliced_arithmetic.h"
+#include <stdalign.h>
+#include <string.h>
+#include <mem.h>
+#include <simple_arithmetic.h>
+#include <echelon_form.h>
+
+#ifdef ENABLE_CT_TESTING
+#include <valgrind/memcheck.h>
+#endif
+
+
+// This implements arithmetic for bitsliced vectors of m field elements in Z_2[x]/(x^4+x+1)
+// A bitsliced vector is consists of m/32 * 4 consecutive uint32_t's
+// the first m/32 uint32_t's are the degree-0 terms, the following m/3 uint32_t's are the degree-1 terms and so on.
+
+void bitsliced_m_vec_mul_add(int m_legs, const uint32_t *in, unsigned char a, uint32_t *acc) {
+    const uint32_t *in0 = in;
+    const uint32_t *in1 = in + m_legs;
+    const uint32_t *in2 = in + 2 * m_legs;
+    const uint32_t *in3 = in + 3 * m_legs;
+
+    uint32_t *acc0 = acc;
+    uint32_t *acc1 = acc + m_legs;
+    uint32_t *acc2 = acc + 2 * m_legs;
+    uint32_t *acc3 = acc + 3 * m_legs;
+
+    // terms of a
+    uint32_t aa = a;
+    uint32_t a0 = -(aa & 1);
+    uint32_t a1 = -((aa >> 1) & 1);
+    uint32_t a2 = -((aa >> 2) & 1);
+    uint32_t a3 = -((aa >> 3) & 1);
+
+    uint32_t x, y, z;
+    for (int i = 0; i < m_legs; i++) {
+        // deg 0 term of a;
+        acc0[i] ^= a0 & in0[i];
+        acc1[i] ^= a0 & in1[i];
+        acc2[i] ^= a0 & in2[i];
+        acc3[i] ^= a0 & in3[i];
+
+        // deg 1 term of a;
+        x = in0[i] ^ in3[i];
+        acc0[i] ^= a1 & in3[i];
+        acc1[i] ^= a1 & x;
+        acc2[i] ^= a1 & in1[i];
+        acc3[i] ^= a1 & in2[i];
+
+        // deg 2 term of a
+        y = in3[i] ^ in2[i];
+        acc0[i] ^= a2 & in2[i];
+        acc1[i] ^= a2 & y;
+        acc2[i] ^= a2 & x;
+        acc3[i] ^= a2 & in1[i];
+
+        // deg 3 term of a
+        z = in2[i] ^ in1[i];
+        acc0[i] ^= a3 & in1[i];
+        acc1[i] ^= a3 & z;
+        acc2[i] ^= a3 & y;
+        acc3[i] ^= a3 & x;
+    }
+}
+
+inline
+static void bitsliced_m_vec_mul_add_x(int m_legs, const uint32_t *in, uint32_t *acc) {
+    const uint32_t *in0 = in;
+    const uint32_t *in1 = in + m_legs;
+    const uint32_t *in2 = in + 2 * m_legs;
+    const uint32_t *in3 = in + 3 * m_legs;
+
+    uint32_t *acc0 = acc;
+    uint32_t *acc1 = acc + m_legs;
+    uint32_t *acc2 = acc + 2 * m_legs;
+    uint32_t *acc3 = acc + 3 * m_legs;
+
+    uint32_t x;
+    for (int i = 0; i < m_legs; i++) {
+        // deg 1 term of a;
+        x = in0[i] ^ in3[i];
+        acc0[i] ^= in3[i];
+        acc1[i] ^= x;
+        acc2[i] ^= in1[i];
+        acc3[i] ^= in2[i];
+    }
+}
+
+void bitsliced_m_upper(int m_legs, const uint32_t *in, uint32_t *out, int size) {
+    int m_vecs_stored = 0;
+    for (int r = 0; r < size; r++) {
+        for (int c = r; c < size; c++) {
+            bitsliced_m_vec_copy(m_legs, in + m_legs * 4 * (r * size + c), out + m_legs * 4 * m_vecs_stored );
+            if (r != c) {
+                bitsliced_m_vec_add(m_legs, in + m_legs * 4 * (c * size + r), out + m_legs * 4 * m_vecs_stored );
+            }
+            m_vecs_stored ++;
+        }
+    }
+}
+
+void bitslice_m_vec(int m_legs, const unsigned char *in, uint32_t *out) {
+    uint32_t *out0 = out;
+    uint32_t *out1 = out + m_legs;
+    uint32_t *out2 = out + 2 * m_legs;
+    uint32_t *out3 = out + 3 * m_legs;
+
+    for (int leg = 0; leg < m_legs; leg++) {
+        uint32_t d0 = 0, d1 = 0, d2 = 0, d3 = 0;
+        for (int i = 31; i >= 0; i--) {
+            d0 = (d0 << 1) ^  (in[32 * leg + i] & 1);
+            d1 = (d1 << 1) ^ ((in[32 * leg + i] & 2) >> 1);
+            d2 = (d2 << 1) ^ ((in[32 * leg + i] & 4) >> 2);
+            d3 = (d3 << 1) ^ ((in[32 * leg + i] & 8) >> 3);
+        }
+        out0[leg] = d0;
+        out1[leg] = d1;
+        out2[leg] = d2;
+        out3[leg] = d3;
+    }
+}
+
+void unbitslice_m_vec(int m_legs, const uint32_t *in, unsigned char *out) {
+    const uint32_t *in0 = in;
+    const uint32_t *in1 = in + m_legs;
+    const uint32_t *in2 = in + 2 * m_legs;
+    const uint32_t *in3 = in + 3 * m_legs;
+
+    for (int leg = 0; leg < m_legs; leg ++) {
+        for (int i = 0; i < 32; i++) {
+            out[leg * 32 + i] = ((in0[leg] >> i) & 1) ^
+                                (((in1[leg] >> i) & 1) << 1) ^
+                                (((in2[leg] >> i) & 1) << 2) ^
+                                (((in3[leg] >> i) & 1) << 3) ;
+        }
+    }
+}
+
+void P1_times_O(const mayo_params_t* p, const uint32_t* P1, const unsigned char* O, uint32_t* acc){
+    #if (MAYO_AVX && defined(MAYO_VARIANT) && M_MAX == 64 && (O_MAX % 2 == 0))
+        mayo_12_P1_times_O(P1,O,acc);
+    #elif (MAYO_AVX && defined(MAYO_VARIANT) && M_MAX == 96 && (O_MAX % 10 == 0))
+        mayo_3_P1_times_O(P1,O,acc);
+    #elif (MAYO_AVX && defined(MAYO_VARIANT) && M_MAX == 128 && (O_MAX % 2 == 0))
+        mayo_5_P1_times_O(P1,O,acc);
+    #else 
+        mul_add_bitsliced_m_upper_triangular_mat_x_mat(p->m/32, P1, O, acc, p->n - p->o, p->n - p->o, p->o, 1);
+    #endif
+}
+
+void P1P1t_times_O(const mayo_params_t* p, const uint32_t* P1, const unsigned char* O, uint32_t* acc){
+    alignas (32) uint32_t P1P1t[N_MINUS_O_MAX * N_MINUS_O_MAX * M_MAX / 8];
+    const int m_legs = PARAM_m(p)/32;
+    // compute P_i^(1) + P_i^(1)t for all i
+    int used = 0;
+    for (int r = 0; r < PARAM_v(p); r++) {
+        for (int c = r; c < (PARAM_v(p)); c++) {
+            if (r == c) {
+                memset((void *)(P1P1t + m_legs * 4 * (r * (PARAM_v(p)) + c)), 0,
+                       PARAM_m(p) / 2);
+            } else {
+                bitsliced_m_vec_copy(m_legs, P1 + m_legs * 4 * used,
+                                     P1P1t + m_legs * 4 * (r * (PARAM_v(p)) + c));
+                bitsliced_m_vec_copy(m_legs, P1 + m_legs * 4 * used,
+                                     P1P1t + m_legs * 4 * (c * (PARAM_v(p)) + r));
+            }
+            used++;
+        }
+    }
+    
+    #if (MAYO_AVX && defined(MAYO_VARIANT) && M_MAX == 64 && (O_MAX % 2 == 0))
+        mayo_12_P1P1t_times_O(P1P1t,O,acc);
+    #elif (MAYO_AVX && defined(MAYO_VARIANT) && M_MAX == 96 && (O_MAX % 10 == 0))
+        mayo_3_P1P1t_times_O(P1P1t,O,acc);
+    #elif (MAYO_AVX && defined(MAYO_VARIANT) && M_MAX == 128 && (O_MAX % 2 == 0))
+        mayo_5_P1P1t_times_O(P1P1t,O,acc);
+    #else
+        mul_add_bitsliced_m_upper_triangular_mat_x_mat(p->m/32, P1P1t, O, acc, p->n - p->o, p->n - p->o, p->o, 0);
+    #endif
+}
+
+void P1_times_Vt(const mayo_params_t* p, const uint32_t* P1, const unsigned char* V, uint32_t* acc){
+    #if (MAYO_AVX && defined(MAYO_VARIANT) && M_MAX == 64 && (K_MAX == 4 || K_MAX == 9))
+        mayo_12_P1_times_Vt(P1,V,acc);
+    #elif (MAYO_AVX && defined(MAYO_VARIANT) && M_MAX == 96 && (K_MAX % 11 == 0))
+        mayo_3_P1_times_Vt(P1,V,acc);
+    #elif (MAYO_AVX && defined(MAYO_VARIANT) && M_MAX == 128 && (K_MAX % 2 == 0))
+        mayo_5_P1_times_Vt(P1,V,acc);
+    #else
+        mul_add_bitsliced_m_upper_triangular_mat_x_mat_trans(p->m/32, P1, V, acc, p->n - p->o, p->n - p->o, p->k, 1);
+    #endif
+}
+
+// multiplies m bitsliced (possibly upper triangular) matrices with a single matrix and adds result to acc
+void mul_add_bitsliced_m_upper_triangular_mat_x_mat(int m_legs, const uint32_t *bs_mat, const unsigned char *mat, uint32_t *acc, int bs_mat_rows, int bs_mat_cols, int mat_cols, int triangular) {
+
+    int bs_mat_entries_used = 0;
+    for (int r = 0; r < bs_mat_rows; r++) {
+        for (int c = triangular * r; c < bs_mat_cols; c++) {
+            for (int k = 0; k < mat_cols; k += 1) {
+#if defined(MAYO_VARIANT) && (M_MAX == 64)
+                (void)m_legs;
+                bitsliced_64_vec_mul_add((uint64_t *) bs_mat + 4 * bs_mat_entries_used, mat[c * mat_cols + k], (uint64_t *) acc + 4 * (r * mat_cols + k));
+#elif defined(MAYO_VARIANT) && (M_MAX == 96)
+                (void)m_legs;
+                bitsliced_96_vec_mul_add(bs_mat + 12 * bs_mat_entries_used, mat[c * mat_cols + k], acc + 12 * (r * mat_cols + k));
+#elif defined(MAYO_VARIANT) && (M_MAX == 128)
+                (void)m_legs;
+                bitsliced_128_vec_mul_add((uint64_t *) bs_mat + 8 * bs_mat_entries_used, mat[c * mat_cols + k], (uint64_t *) acc + 8 * (r * mat_cols + k));
+#else
+                bitsliced_m_vec_mul_add(m_legs, bs_mat + m_legs * 4 * bs_mat_entries_used, mat[c * mat_cols + k], acc + m_legs * 4 * (r * mat_cols + k));
+#endif
+            }
+            bs_mat_entries_used += 1;
+        }
+    }
+}
+
+// multiplies m bitsliced (possibly upper triangular) matrices with the transpose of a single matrix and adds result to acc
+void mul_add_bitsliced_m_upper_triangular_mat_x_mat_trans(int m_legs, const uint32_t *bs_mat, const unsigned char *mat, uint32_t *acc, int bs_mat_rows, int bs_mat_cols, int mat_rows, int triangular) {
+
+    int bs_mat_entries_used = 0;
+    for (int r = 0; r < bs_mat_rows; r++) {
+        for (int c = triangular * r; c < bs_mat_cols; c++) {
+            for (int k = 0; k < mat_rows; k += 1) {
+#if defined(MAYO_VARIANT) && (M_MAX == 64)
+                (void)m_legs;
+                bitsliced_64_vec_mul_add((uint64_t *) bs_mat + 4 * bs_mat_entries_used, mat[k * bs_mat_cols + c], (uint64_t *) acc + 4 * (r * mat_rows + k));
+#elif defined(MAYO_VARIANT) && (M_MAX == 96)
+                (void)m_legs;
+                bitsliced_96_vec_mul_add(bs_mat + 12 * bs_mat_entries_used, mat[k * bs_mat_cols + c], acc + 12 * (r * mat_rows + k));
+#elif defined(MAYO_VARIANT) && (M_MAX == 128)
+                (void)m_legs;
+                bitsliced_128_vec_mul_add((uint64_t *) bs_mat + 8 * bs_mat_entries_used, mat[k * bs_mat_cols + c], (uint64_t *) acc + 8 * (r * mat_rows + k));
+#else
+                bitsliced_m_vec_mul_add(m_legs, bs_mat + m_legs * 4 * bs_mat_entries_used, mat[k * bs_mat_cols + c], acc + m_legs * 4 * (r * mat_rows + k));
+#endif
+            }
+            bs_mat_entries_used += 1;
+        }
+    }
+}
+
+// multiplies the transpose of a single matrix with m bitsliced matrices and adds result to acc
+void mul_add_mat_trans_x_bitsliced_m_mat(int m_legs, const unsigned char *mat, const uint32_t *bs_mat, uint32_t *acc, int mat_rows, int mat_cols, int bs_mat_cols) {
+
+    for (int r = 0; r < mat_cols; r++) {
+        for (int c = 0; c < mat_rows; c++) {
+            for (int k = 0; k < bs_mat_cols; k += 1) {
+#if defined(MAYO_VARIANT) && (M_MAX == 64)
+                (void)m_legs;
+                bitsliced_64_vec_mul_add((uint64_t *)bs_mat + 4 * (c * bs_mat_cols + k), mat[c * mat_cols + r], (uint64_t *) acc + 4 * (r * bs_mat_cols + k));
+#elif defined(MAYO_VARIANT) && (M_MAX == 96)
+                (void)m_legs;
+                bitsliced_96_vec_mul_add(bs_mat + 12 * (c * bs_mat_cols + k), mat[c * mat_cols + r], acc + 12 * (r * bs_mat_cols + k));
+#elif defined(MAYO_VARIANT) && (M_MAX == 128)
+                (void)m_legs;
+                bitsliced_128_vec_mul_add((uint64_t *)bs_mat + 8 * (c * bs_mat_cols + k), mat[c * mat_cols + r], (uint64_t *) acc + 8 * (r * bs_mat_cols + k));
+#else
+                bitsliced_m_vec_mul_add(m_legs, bs_mat + m_legs * 4 * (c * bs_mat_cols + k), mat[c * mat_cols + r], acc + m_legs * 4 * (r * bs_mat_cols + k));
+#endif
+            }
+        }
+    }
+}
+
+// multiplies a single matrix with m bitsliced matrices and adds result to acc
+void mul_add_mat_x_bitsliced_m_mat(int m_legs, const unsigned char *mat, const uint32_t *bs_mat, uint32_t *acc, int mat_rows, int mat_cols, int bs_mat_cols) {
+
+    for (int r = 0; r < mat_rows; r++) {
+        for (int c = 0; c < mat_cols; c++) {
+            for (int k = 0; k < bs_mat_cols; k += 1) {
+#if defined(MAYO_VARIANT) && (M_MAX == 64)
+                (void)m_legs;
+                bitsliced_64_vec_mul_add((uint64_t *)bs_mat + 4 * (c * bs_mat_cols + k), mat[r * mat_cols + c], (uint64_t *) acc + 4 * (r * bs_mat_cols + k));
+#elif defined(MAYO_VARIANT) && (M_MAX == 96)
+                (void)m_legs;
+                bitsliced_96_vec_mul_add(bs_mat + 12 * (c * bs_mat_cols + k), mat[r * mat_cols + c], acc + 12 * (r * bs_mat_cols + k));
+#elif defined(MAYO_VARIANT) && (M_MAX == 128)
+                (void)m_legs;
+                bitsliced_128_vec_mul_add((uint64_t *)bs_mat + 8 * (c * bs_mat_cols + k), mat[r * mat_cols + c], (uint64_t *) acc + 8 * (r * bs_mat_cols + k));
+#else
+                bitsliced_m_vec_mul_add(m_legs, bs_mat + m_legs * 4 * (c * bs_mat_cols + k), mat[r * mat_cols + c], acc + m_legs * 4 * (r * bs_mat_cols + k));
+#endif
+            }
+        }
+    }
+}
+
+void bitsliced_m_calculate_PS_SPS(const uint32_t *bitsliced_P1, const uint32_t *bitsliced_P2, const uint32_t *bitsliced_P3, const unsigned char *S,
+                              const int m, const int v, const int o, const int k, uint32_t *bitsliced_SPS){
+    // compute P * S^t = {(P1, P2), (0, P3)} * S^t = {(P1*S1 + P2*S2), (P3 * S2)}
+    alignas (32) uint32_t bitsliced_PS[N_MAX * K_MAX * M_MAX / 8];
+    const int m_legs = m/32;
+    const int n = v+o;
+    bitsliced_m_calculate_PS(bitsliced_P1, bitsliced_P2, bitsliced_P3, S, m,
+                             v, o, k, bitsliced_PS);
+
+    mul_add_mat_x_bitsliced_m_mat(m_legs, S, bitsliced_PS, bitsliced_SPS, k,
+                                  n, k);
+
+}
+
+void bitsliced_m_multiply_bins(const int m_legs, uint32_t *bins, uint32_t *out) {
+
+    bitsliced_m_vec_add(m_legs, bins + 15 * m_legs * 4, bins + 12 * m_legs * 4);
+    bitsliced_m_vec_add(m_legs, bins + 15 * m_legs * 4, bins +  3 * m_legs * 4);
+
+    bitsliced_m_vec_add(m_legs, bins + 14 * m_legs * 4, bins +  8 * m_legs * 4);
+    bitsliced_m_vec_add(m_legs, bins + 14 * m_legs * 4, bins +  6 * m_legs * 4);
+
+    bitsliced_m_vec_add(m_legs, bins + 13 * m_legs * 4, bins + 10 * m_legs * 4);
+    bitsliced_m_vec_add(m_legs, bins + 13 * m_legs * 4, bins +  7 * m_legs * 4);
+
+    bitsliced_m_vec_add(m_legs, bins + 12 * m_legs * 4, bins +  8 * m_legs * 4);
+    bitsliced_m_vec_add(m_legs, bins + 12 * m_legs * 4, bins +  4 * m_legs * 4);
+
+    bitsliced_m_vec_add(m_legs, bins + 11 * m_legs * 4, bins +  9 * m_legs * 4);
+    bitsliced_m_vec_add(m_legs, bins + 11 * m_legs * 4, bins +  2 * m_legs * 4);
+
+    bitsliced_m_vec_add(m_legs, bins + 10 * m_legs * 4, bins +  8 * m_legs * 4);
+    bitsliced_m_vec_add(m_legs, bins + 10 * m_legs * 4, bins +  2 * m_legs * 4);
+
+    bitsliced_m_vec_add(m_legs, bins + 9 * m_legs * 4, bins +  8 * m_legs * 4);
+    bitsliced_m_vec_add(m_legs, bins + 9 * m_legs * 4, bins +  1 * m_legs * 4);
+
+    bitsliced_m_vec_add(m_legs, bins + 7 * m_legs * 4, bins +  4 * m_legs * 4);
+    bitsliced_m_vec_add(m_legs, bins + 7 * m_legs * 4, bins +  3 * m_legs * 4);
+
+    bitsliced_m_vec_add(m_legs, bins + 6 * m_legs * 4, bins +  4 * m_legs * 4);
+    bitsliced_m_vec_add(m_legs, bins + 6 * m_legs * 4, bins +  2 * m_legs * 4);
+
+    bitsliced_m_vec_add(m_legs, bins + 5 * m_legs * 4, bins +  4 * m_legs * 4);
+    bitsliced_m_vec_add(m_legs, bins + 5 * m_legs * 4, bins +  1 * m_legs * 4);
+
+    bitsliced_m_vec_add(m_legs, bins + 3 * m_legs * 4, bins +  2 * m_legs * 4);
+    bitsliced_m_vec_add(m_legs, bins + 3 * m_legs * 4, bins +  1 * m_legs * 4);
+
+    bitsliced_m_vec_mul_add_x(m_legs, bins + 8 * m_legs * 4, bins + 4 * m_legs * 4);
+    bitsliced_m_vec_mul_add_x(m_legs, bins + 4 * m_legs * 4, bins + 2 * m_legs * 4);
+    bitsliced_m_vec_mul_add_x(m_legs, bins + 2 * m_legs * 4, bins + 1 * m_legs * 4);
+
+    bitsliced_m_vec_copy(m_legs, bins + 1 * m_legs * 4, out);
+}
+
+// compute P * S^t = [ P1  P2 ] * [S1] = [P1*S1 + P2*S2] in bitsliced form
+//                   [  0  P3 ]   [S2]   [        P3*S2]
+void bitsliced_m_calculate_PS(const uint32_t *P1, const uint32_t *P2, const uint32_t *P3, const unsigned char *S,
+                              const int m, const int v, const int o, const int k, uint32_t *PS) {
+
+    const int n = o + v;
+#if defined(MAYO_VARIANT) && ((M_MAX == 64) || (M_MAX == 96) || M_MAX == 128)
+    (void) m;
+#else
+    const int m_legs = m / 32;
+#endif
+
+    /* Old approach which is constant time but doesn't have to be
+    unsigned char S1[V_MAX*K_MAX];
+    unsigned char S2[O_MAX*K_MAX];
+    unsigned char *s1_write = S1;
+    unsigned char *s2_write = S2;
+    for (int r=0; r < k; r++)
+    {
+        for (int c = 0; c < n; c++)
+        {
+            if(c < v){
+                *(s1_write++) = S[r*n + c];
+            } else {
+                *(s2_write++) = S[r*n + c];
+            }
+        }
+    }
+
+    mul_add_bitsliced_m_upper_triangular_mat_x_mat_trans(m_legs, P1, S1, PS, v, v, k, 1); // P1 * S1
+    mul_add_bitsliced_m_upper_triangular_mat_x_mat_trans(m_legs, P2, S2, PS, v, o, k, 0); // P2 * S2
+    mul_add_bitsliced_m_upper_triangular_mat_x_mat_trans(m_legs, P3, S2, PS + v*k*m_legs*4, o, o, k, 1); // P3 * S2
+    */
+
+    alignas (32) uint32_t accumulator[16 * M_MAX * K_MAX * N_MAX / 8] = {0};
+    int P1_used = 0;
+    for (int row = 0; row < v; row++) {
+        for (int j = row; j < v; j++) {
+#if defined(MAYO_VARIANT) && (M_MAX == 64) && (K_MAX == 9)
+            bitsliced_64_vec_add((uint64_t *) (P1 + P1_used * 8), (uint64_t *) (accumulator + ( (row * k + 0) * 16 + S[0 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P1 + P1_used * 8), (uint64_t *) (accumulator + ( (row * k + 1) * 16 + S[1 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P1 + P1_used * 8), (uint64_t *) (accumulator + ( (row * k + 2) * 16 + S[2 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P1 + P1_used * 8), (uint64_t *) (accumulator + ( (row * k + 3) * 16 + S[3 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P1 + P1_used * 8), (uint64_t *) (accumulator + ( (row * k + 4) * 16 + S[4 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P1 + P1_used * 8), (uint64_t *) (accumulator + ( (row * k + 5) * 16 + S[5 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P1 + P1_used * 8), (uint64_t *) (accumulator + ( (row * k + 6) * 16 + S[6 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P1 + P1_used * 8), (uint64_t *) (accumulator + ( (row * k + 7) * 16 + S[7 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P1 + P1_used * 8), (uint64_t *) (accumulator + ( (row * k + 8) * 16 + S[8 * n + j] ) * 8 ));
+#elif defined(MAYO_VARIANT) && (M_MAX == 64) && (K_MAX == 4)
+            bitsliced_64_vec_add((uint64_t *) (P1 + P1_used * 8), (uint64_t *) (accumulator + ( (row * k + 0) * 16 + S[0 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P1 + P1_used * 8), (uint64_t *) (accumulator + ( (row * k + 1) * 16 + S[1 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P1 + P1_used * 8), (uint64_t *) (accumulator + ( (row * k + 2) * 16 + S[2 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P1 + P1_used * 8), (uint64_t *) (accumulator + ( (row * k + 3) * 16 + S[3 * n + j] ) * 8 ));
+#elif defined(MAYO_VARIANT) && (M_MAX == 96) && (K_MAX == 11)
+            bitsliced_96_vec_add(P1 + P1_used * 12, accumulator + ( (row * k + 0) * 16 + S[0 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P1 + P1_used * 12, accumulator + ( (row * k + 1) * 16 + S[1 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P1 + P1_used * 12, accumulator + ( (row * k + 2) * 16 + S[2 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P1 + P1_used * 12, accumulator + ( (row * k + 3) * 16 + S[3 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P1 + P1_used * 12, accumulator + ( (row * k + 4) * 16 + S[4 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P1 + P1_used * 12, accumulator + ( (row * k + 5) * 16 + S[5 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P1 + P1_used * 12, accumulator + ( (row * k + 6) * 16 + S[6 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P1 + P1_used * 12, accumulator + ( (row * k + 7) * 16 + S[7 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P1 + P1_used * 12, accumulator + ( (row * k + 8) * 16 + S[8 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P1 + P1_used * 12, accumulator + ( (row * k + 9) * 16 + S[9 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P1 + P1_used * 12, accumulator + ( (row * k + 10) * 16 + S[10 * n + j] ) * 12 );
+#elif defined(MAYO_VARIANT) && (M_MAX == 128) && (K_MAX == 12)
+            bitsliced_128_vec_add((uint64_t *) (P1 + P1_used * 16), (uint64_t *) (accumulator + ( (row * k + 0) * 16 + S[0 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P1 + P1_used * 16), (uint64_t *) (accumulator + ( (row * k + 1) * 16 + S[1 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P1 + P1_used * 16), (uint64_t *) (accumulator + ( (row * k + 2) * 16 + S[2 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P1 + P1_used * 16), (uint64_t *) (accumulator + ( (row * k + 3) * 16 + S[3 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P1 + P1_used * 16), (uint64_t *) (accumulator + ( (row * k + 4) * 16 + S[4 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P1 + P1_used * 16), (uint64_t *) (accumulator + ( (row * k + 5) * 16 + S[5 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P1 + P1_used * 16), (uint64_t *) (accumulator + ( (row * k + 6) * 16 + S[6 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P1 + P1_used * 16), (uint64_t *) (accumulator + ( (row * k + 7) * 16 + S[7 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P1 + P1_used * 16), (uint64_t *) (accumulator + ( (row * k + 8) * 16 + S[8 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P1 + P1_used * 16), (uint64_t *) (accumulator + ( (row * k + 9) * 16 + S[9 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P1 + P1_used * 16), (uint64_t *) (accumulator + ( (row * k + 10) * 16 + S[10 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P1 + P1_used * 16), (uint64_t *) (accumulator + ( (row * k + 11) * 16 + S[11 * n + j] ) * 16 ));
+#else
+            for (int col = 0; col < k; col++) {
+                bitsliced_m_vec_add(m_legs, P1 + P1_used * m_legs * 4, accumulator + ( (row * k + col) * 16 + S[col * n + j] )*m_legs * 4 );
+            }
+#endif
+            P1_used ++;
+        }
+
+        for (int j = 0; j < o; j++) {
+#if defined(MAYO_VARIANT) && (M_MAX == 64) && (K_MAX == 9)
+            bitsliced_64_vec_add((uint64_t *) (P2 + (row * o + j) * 8), (uint64_t *) ( accumulator + ( (row * k + 0) * 16 + S[(0 * n) + j + v] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P2 + (row * o + j) * 8), (uint64_t *) ( accumulator + ( (row * k + 1) * 16 + S[(1 * n) + j + v] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P2 + (row * o + j) * 8), (uint64_t *) ( accumulator + ( (row * k + 2) * 16 + S[(2 * n) + j + v] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P2 + (row * o + j) * 8), (uint64_t *) ( accumulator + ( (row * k + 3) * 16 + S[(3 * n) + j + v] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P2 + (row * o + j) * 8), (uint64_t *) ( accumulator + ( (row * k + 4) * 16 + S[(4 * n) + j + v] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P2 + (row * o + j) * 8), (uint64_t *) ( accumulator + ( (row * k + 5) * 16 + S[(5 * n) + j + v] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P2 + (row * o + j) * 8), (uint64_t *) ( accumulator + ( (row * k + 6) * 16 + S[(6 * n) + j + v] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P2 + (row * o + j) * 8), (uint64_t *) ( accumulator + ( (row * k + 7) * 16 + S[(7 * n) + j + v] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P2 + (row * o + j) * 8), (uint64_t *) ( accumulator + ( (row * k + 8) * 16 + S[(8 * n) + j + v] ) * 8 ));
+#elif defined(MAYO_VARIANT) && (M_MAX == 64) && (K_MAX == 4)
+            bitsliced_64_vec_add((uint64_t *) (P2 + (row * o + j) * 8), (uint64_t *) ( accumulator + ( (row * k + 0) * 16 + S[(0 * n) + j + v] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P2 + (row * o + j) * 8), (uint64_t *) ( accumulator + ( (row * k + 1) * 16 + S[(1 * n) + j + v] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P2 + (row * o + j) * 8), (uint64_t *) ( accumulator + ( (row * k + 2) * 16 + S[(2 * n) + j + v] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P2 + (row * o + j) * 8), (uint64_t *) ( accumulator + ( (row * k + 3) * 16 + S[(3 * n) + j + v] ) * 8 ));
+#elif defined(MAYO_VARIANT) && (M_MAX == 96) && (K_MAX == 11)
+            bitsliced_96_vec_add(P2 + (row * o + j) * 12, accumulator + ( (row * k + 0) * 16 + S[(0 * n) + j + v] ) * 12 );
+            bitsliced_96_vec_add(P2 + (row * o + j) * 12, accumulator + ( (row * k + 1) * 16 + S[(1 * n) + j + v] ) * 12 );
+            bitsliced_96_vec_add(P2 + (row * o + j) * 12, accumulator + ( (row * k + 2) * 16 + S[(2 * n) + j + v] ) * 12 );
+            bitsliced_96_vec_add(P2 + (row * o + j) * 12, accumulator + ( (row * k + 3) * 16 + S[(3 * n) + j + v] ) * 12 );
+            bitsliced_96_vec_add(P2 + (row * o + j) * 12, accumulator + ( (row * k + 4) * 16 + S[(4 * n) + j + v] ) * 12 );
+            bitsliced_96_vec_add(P2 + (row * o + j) * 12, accumulator + ( (row * k + 5) * 16 + S[(5 * n) + j + v] ) * 12 );
+            bitsliced_96_vec_add(P2 + (row * o + j) * 12, accumulator + ( (row * k + 6) * 16 + S[(6 * n) + j + v] ) * 12 );
+            bitsliced_96_vec_add(P2 + (row * o + j) * 12, accumulator + ( (row * k + 7) * 16 + S[(7 * n) + j + v] ) * 12 );
+            bitsliced_96_vec_add(P2 + (row * o + j) * 12, accumulator + ( (row * k + 8) * 16 + S[(8 * n) + j + v] ) * 12 );
+            bitsliced_96_vec_add(P2 + (row * o + j) * 12, accumulator + ( (row * k + 9) * 16 + S[(9 * n) + j + v] ) * 12 );
+            bitsliced_96_vec_add(P2 + (row * o + j) * 12, accumulator + ( (row * k + 10) * 16 + S[(10 * n) + j + v] ) * 12 );
+#elif defined(MAYO_VARIANT) && (M_MAX == 128) && (K_MAX == 12)
+            bitsliced_128_vec_add((uint64_t *) (P2 + (row * o + j) * 16), (uint64_t *) ( accumulator + ( (row * k + 0) * 16 + S[(0 * n) + j + v] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P2 + (row * o + j) * 16), (uint64_t *) ( accumulator + ( (row * k + 1) * 16 + S[(1 * n) + j + v] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P2 + (row * o + j) * 16), (uint64_t *) ( accumulator + ( (row * k + 2) * 16 + S[(2 * n) + j + v] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P2 + (row * o + j) * 16), (uint64_t *) ( accumulator + ( (row * k + 3) * 16 + S[(3 * n) + j + v] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P2 + (row * o + j) * 16), (uint64_t *) ( accumulator + ( (row * k + 4) * 16 + S[(4 * n) + j + v] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P2 + (row * o + j) * 16), (uint64_t *) ( accumulator + ( (row * k + 5) * 16 + S[(5 * n) + j + v] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P2 + (row * o + j) * 16), (uint64_t *) ( accumulator + ( (row * k + 6) * 16 + S[(6 * n) + j + v] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P2 + (row * o + j) * 16), (uint64_t *) ( accumulator + ( (row * k + 7) * 16 + S[(7 * n) + j + v] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P2 + (row * o + j) * 16), (uint64_t *) ( accumulator + ( (row * k + 8) * 16 + S[(8 * n) + j + v] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P2 + (row * o + j) * 16), (uint64_t *) ( accumulator + ( (row * k + 9) * 16 + S[(9 * n) + j + v] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P2 + (row * o + j) * 16), (uint64_t *) ( accumulator + ( (row * k + 10) * 16 + S[(10 * n) + j + v] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P2 + (row * o + j) * 16), (uint64_t *) ( accumulator + ( (row * k + 11) * 16 + S[(11 * n) + j + v] ) * 16 ));
+#else
+            for (int col = 0; col < k; col++) {
+                bitsliced_m_vec_add(m_legs, P2 + (row * o + j)*m_legs * 4, accumulator + ( (row * k + col) * 16 + S[(col * n) + j + v] )*m_legs * 4 );
+            }
+#endif
+        }
+    }
+
+    int P3_used = 0;
+    for (int row = v; row < n; row++) {
+        for (int j = row; j < n; j++) {
+#if defined(MAYO_VARIANT) && (M_MAX == 64) && (K_MAX == 9)
+            bitsliced_64_vec_add((uint64_t *) (P3 + P3_used * 8), (uint64_t *) (accumulator + ( (row * k + 0) * 16 + S[0 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P3 + P3_used * 8), (uint64_t *) (accumulator + ( (row * k + 1) * 16 + S[1 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P3 + P3_used * 8), (uint64_t *) (accumulator + ( (row * k + 2) * 16 + S[2 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P3 + P3_used * 8), (uint64_t *) (accumulator + ( (row * k + 3) * 16 + S[3 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P3 + P3_used * 8), (uint64_t *) (accumulator + ( (row * k + 4) * 16 + S[4 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P3 + P3_used * 8), (uint64_t *) (accumulator + ( (row * k + 5) * 16 + S[5 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P3 + P3_used * 8), (uint64_t *) (accumulator + ( (row * k + 6) * 16 + S[6 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P3 + P3_used * 8), (uint64_t *) (accumulator + ( (row * k + 7) * 16 + S[7 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P3 + P3_used * 8), (uint64_t *) (accumulator + ( (row * k + 8) * 16 + S[8 * n + j] ) * 8 ));
+#elif defined(MAYO_VARIANT) && (M_MAX == 64) && (K_MAX == 4)
+            bitsliced_64_vec_add((uint64_t *) (P3 + P3_used * 8), (uint64_t *) (accumulator + ( (row * k + 0) * 16 + S[0 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P3 + P3_used * 8), (uint64_t *) (accumulator + ( (row * k + 1) * 16 + S[1 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P3 + P3_used * 8), (uint64_t *) (accumulator + ( (row * k + 2) * 16 + S[2 * n + j] ) * 8 ));
+            bitsliced_64_vec_add((uint64_t *) (P3 + P3_used * 8), (uint64_t *) (accumulator + ( (row * k + 3) * 16 + S[3 * n + j] ) * 8 ));
+#elif defined(MAYO_VARIANT) && (M_MAX == 96) && (K_MAX == 11)
+            bitsliced_96_vec_add(P3 + P3_used * 12, accumulator + ( (row * k + 0) * 16 + S[0 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P3 + P3_used * 12, accumulator + ( (row * k + 1) * 16 + S[1 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P3 + P3_used * 12, accumulator + ( (row * k + 2) * 16 + S[2 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P3 + P3_used * 12, accumulator + ( (row * k + 3) * 16 + S[3 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P3 + P3_used * 12, accumulator + ( (row * k + 4) * 16 + S[4 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P3 + P3_used * 12, accumulator + ( (row * k + 5) * 16 + S[5 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P3 + P3_used * 12, accumulator + ( (row * k + 6) * 16 + S[6 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P3 + P3_used * 12, accumulator + ( (row * k + 7) * 16 + S[7 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P3 + P3_used * 12, accumulator + ( (row * k + 8) * 16 + S[8 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P3 + P3_used * 12, accumulator + ( (row * k + 9) * 16 + S[9 * n + j] ) * 12 );
+            bitsliced_96_vec_add(P3 + P3_used * 12, accumulator + ( (row * k + 10) * 16 + S[10 * n + j] ) * 12 );
+#elif defined(MAYO_VARIANT) && (M_MAX == 128) && (K_MAX == 12)
+            bitsliced_128_vec_add((uint64_t *) (P3 + P3_used * 16), (uint64_t *) (accumulator + ( (row * k + 0) * 16 + S[0 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P3 + P3_used * 16), (uint64_t *) (accumulator + ( (row * k + 1) * 16 + S[1 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P3 + P3_used * 16), (uint64_t *) (accumulator + ( (row * k + 2) * 16 + S[2 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P3 + P3_used * 16), (uint64_t *) (accumulator + ( (row * k + 3) * 16 + S[3 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P3 + P3_used * 16), (uint64_t *) (accumulator + ( (row * k + 4) * 16 + S[4 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P3 + P3_used * 16), (uint64_t *) (accumulator + ( (row * k + 5) * 16 + S[5 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P3 + P3_used * 16), (uint64_t *) (accumulator + ( (row * k + 6) * 16 + S[6 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P3 + P3_used * 16), (uint64_t *) (accumulator + ( (row * k + 7) * 16 + S[7 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P3 + P3_used * 16), (uint64_t *) (accumulator + ( (row * k + 8) * 16 + S[8 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P3 + P3_used * 16), (uint64_t *) (accumulator + ( (row * k + 9) * 16 + S[9 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P3 + P3_used * 16), (uint64_t *) (accumulator + ( (row * k + 10) * 16 + S[10 * n + j] ) * 16 ));
+            bitsliced_128_vec_add((uint64_t *) (P3 + P3_used * 16), (uint64_t *) (accumulator + ( (row * k + 11) * 16 + S[11 * n + j] ) * 16 ));
+#else
+            for (int col = 0; col < k; col++) {
+                bitsliced_m_vec_add(m_legs, P3 + P3_used * m_legs * 4, accumulator + ( (row * k + col) * 16 + S[col * n + j] )*m_legs * 4 );
+            }
+#endif
+            P3_used ++;
+        }
+    }
+
+    // multiply stuff according to the bins of the accumulator and add to PS.
+    int i = 0;
+    while (i < n * k) {
+#if defined(MAYO_VARIANT) && (M_MAX == 64)
+        bitsliced_64_multiply_bins(accumulator + i * 16 * 8, PS + i * 8);
+        i++;
+#elif defined(MAYO_VARIANT) && (M_MAX == 96)
+        bitsliced_96_multiply_bins(accumulator + i * 16 * 12, PS + i * 12);
+        i++;
+#elif defined(MAYO_VARIANT) && (M_MAX == 128)
+        bitsliced_128_multiply_bins(accumulator + i * 16 * 16, PS + i * 16);
+        i++;
+#else
+        bitsliced_m_multiply_bins(m_legs, accumulator + i * 16 * m_legs * 4, PS + i * m_legs * 4);
+        i++;
+#endif
+    }
+}
+
+
+// sample a solution x to Ax = y, with r used as randomness
+// require:
+// - A is a matrix with m rows and k*o+1 collumns (values in the last collum are
+// not important, they will be overwritten by y) in row major order
+// - y is a vector with m elements
+// - r and x are k*o bytes long
+// return: 1 on success, 0 on failure
+int sample_solution(const mayo_params_t *p, unsigned char *A,
+                           const unsigned char *y, const unsigned char *r,
+                           unsigned char *x,int k, int o, int m, int A_cols) {
+    (void) p;
+    unsigned char finished;
+    int col_upper_bound;
+    unsigned char correct_column;
+
+    // x <- r
+    for (int i = 0; i < k * o; i++) {
+        x[i] = r[i];
+    }
+
+    // compute Ar;
+    unsigned char Ar[M_MAX];
+    for (int i = 0; i < m; i++) {
+        A[k * o + i * (k * o + 1)] = 0; // clear last col of A
+    }
+    mat_mul(A, r, Ar, k * o + 1, m, 1);
+
+    // move y - Ar to last column of matrix A
+    for (int i = 0; i < m; i++) {
+        A[k * o + i * (k * o + 1)] = sub_f(y[i], Ar[i]);
+    }
+
+    EF(A, m, k * o + 1);
+
+    // check if last row of A (excluding the last entry of y) is zero
+    unsigned char full_rank = 0;
+    for (int i = 0; i < A_cols - 1; i++) {
+        full_rank |= A[(m - 1) * A_cols + i];
+    }
+
+// It is okay to leak if we need to restart or not
+#ifdef ENABLE_CT_TESTING
+    VALGRIND_MAKE_MEM_DEFINED(&full_rank, 1);
+#endif
+
+    if (full_rank == 0) {
+        return 0;
+    }
+
+    // back substitution in constant time
+    // the index of the first nonzero entry in each row is secret, which makes
+    // things less efficient
+
+    for (int rr = m - 1; rr >= 0; rr--) {
+        finished = 0;
+        col_upper_bound = MAYO_MIN(rr + (32/(m-rr)), k*o);
+        // the first nonzero entry in row r is between r and col_upper_bound with probability at least ~1-q^{-32}
+
+        for (int col = rr; col <= col_upper_bound; col++) {
+
+            // Compare two chars in constant time.
+            // Returns 0x00 if the byte arrays are equal, 0xff otherwise.
+            correct_column = ct_compare_8((A[rr * A_cols + col]), 0) & ~finished;
+
+            unsigned char u = correct_column & A[rr * A_cols + A_cols - 1];
+            x[col] ^= u;
+
+            for (int i = 0; i < rr; i += 8) {
+                uint64_t tmp = ( (uint64_t) A[ i    * A_cols + col] <<  0) ^ ( (uint64_t) A[(i+1) * A_cols + col] <<  8)
+                             ^ ( (uint64_t) A[(i+2) * A_cols + col] << 16) ^ ( (uint64_t) A[(i+3) * A_cols + col] << 24)
+                             ^ ( (uint64_t) A[(i+4) * A_cols + col] << 32) ^ ( (uint64_t) A[(i+5) * A_cols + col] << 40)
+                             ^ ( (uint64_t) A[(i+6) * A_cols + col] << 48) ^ ( (uint64_t) A[(i+7) * A_cols + col] << 56);
+
+                tmp = mul_fx8(u, tmp);
+
+                A[ i    * A_cols + A_cols - 1] ^= (tmp      ) & 0xf;
+                A[(i+1) * A_cols + A_cols - 1] ^= (tmp >> 8 ) & 0xf;
+                A[(i+2) * A_cols + A_cols - 1] ^= (tmp >> 16) & 0xf;
+                A[(i+3) * A_cols + A_cols - 1] ^= (tmp >> 24) & 0xf;
+                A[(i+4) * A_cols + A_cols - 1] ^= (tmp >> 32) & 0xf;
+                A[(i+5) * A_cols + A_cols - 1] ^= (tmp >> 40) & 0xf;
+                A[(i+6) * A_cols + A_cols - 1] ^= (tmp >> 48) & 0xf;
+                A[(i+7) * A_cols + A_cols - 1] ^= (tmp >> 56) & 0xf;
+            }
+
+            finished = finished | correct_column;
+        }
+    }
+    return 1;
+}

--- a/crypto_sign/mayo1/ref/bitsliced_arithmetic.h
+++ b/crypto_sign/mayo1/ref/bitsliced_arithmetic.h
@@ -1,0 +1,136 @@
+
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef BITSLICED_ARITHMETIC_H
+#define BITSLICED_ARITHMETIC_H
+
+#include <bitsliced_arithmetic_64.h>
+#include <bitsliced_arithmetic_96.h>
+#include <bitsliced_arithmetic_128.h>
+#include <stdint.h>
+#include <mayo.h>
+#include <stdint.h>
+
+// This implements arithmetic for bitsliced vectors of m field elements in
+// Z_2[x]/(x^4+x+1)
+
+#ifdef ENABLE_PARAMS_DYNAMIC
+#define PARAM_m(p) (p->m)
+#define PARAM_n(p) (p->n)
+#define PARAM_o(p) (p->o)
+#define PARAM_v(p) (p->n - p->o)
+#define PARAM_A_cols(p) (p->k * p->o + 1)
+#define PARAM_k(p) (p->k)
+#define PARAM_q(p) (p->q)
+#define PARAM_m_bytes(p) (p->m_bytes)
+#define PARAM_O_bytes(p) (p->O_bytes)
+#define PARAM_v_bytes(p) (p->v_bytes)
+#define PARAM_r_bytes(p) (p->r_bytes)
+#define PARAM_P1_bytes(p) (p->P1_bytes)
+#define PARAM_P2_bytes(p) (p->P2_bytes)
+#define PARAM_P3_bytes(p) (p->P3_bytes)
+#define PARAM_csk_bytes(p) (p->csk_bytes)
+#define PARAM_esk_bytes(p) (p->esk_bytes)
+#define PARAM_cpk_bytes(p) (p->cpk_bytes)
+#define PARAM_epk_bytes(p) (p->epk_bytes)
+#define PARAM_sig_bytes(p) (p->sig_bytes)
+#define PARAM_f_tail(p) (p->f_tail)
+#define PARAM_salt_bytes(p) (p->salt_bytes)
+#define PARAM_sk_seed_bytes(p) (p->sk_seed_bytes)
+#define PARAM_digest_bytes(p) (p->digest_bytes)
+#define PARAM_pk_seed_bytes(p) (p->pk_seed_bytes)
+#elif defined(MAYO_VARIANT)
+#define PARAM_m(p) PARAM_NAME(m)
+#define PARAM_n(p) PARAM_NAME(n)
+#define PARAM_o(p) PARAM_NAME(o)
+#define PARAM_v(p) PARAM_NAME(v)
+#define PARAM_A_cols(p) PARAM_NAME(A_cols)
+#define PARAM_k(p) PARAM_NAME(k)
+#define PARAM_q(p) PARAM_NAME(q)
+#define PARAM_m_bytes(p) PARAM_NAME(m_bytes)
+#define PARAM_O_bytes(p) PARAM_NAME(O_bytes)
+#define PARAM_v_bytes(p) PARAM_NAME(v_bytes)
+#define PARAM_r_bytes(p) PARAM_NAME(r_bytes)
+#define PARAM_P1_bytes(p) PARAM_NAME(P1_bytes)
+#define PARAM_P2_bytes(p) PARAM_NAME(P2_bytes)
+#define PARAM_P3_bytes(p) PARAM_NAME(P3_bytes)
+#define PARAM_csk_bytes(p) PARAM_NAME(csk_bytes)
+#define PARAM_esk_bytes(p) PARAM_NAME(esk_bytes)
+#define PARAM_cpk_bytes(p) PARAM_NAME(cpk_bytes)
+#define PARAM_epk_bytes(p) PARAM_NAME(epk_bytes)
+#define PARAM_sig_bytes(p) PARAM_NAME(sig_bytes)
+static const unsigned char f_tail[] = PARAM_NAME(f_tail);
+#define PARAM_salt_bytes(p) PARAM_NAME(salt_bytes)
+#define PARAM_sk_seed_bytes(p) PARAM_NAME(sk_seed_bytes)
+#define PARAM_digest_bytes(p) PARAM_NAME(digest_bytes)
+#define PARAM_pk_seed_bytes(p) PARAM_NAME(pk_seed_bytes)
+#define PARAM_f_tail(p) f_tail
+#else
+#error "Parameter not specified"
+#endif
+
+static
+inline void bitsliced_m_vec_copy(int m_legs, const uint32_t *in,
+                                 uint32_t *out) {
+    for (int i = 0; i < m_legs * 4; i++) {
+        out[i] = in[i];
+    }
+}
+
+static
+inline void bitsliced_m_vec_sum(int m_legs, const uint32_t *in1,
+                                const uint32_t *in2, uint32_t *out) {
+    for (int i = 0; i < m_legs * 4; i++) {
+        out[i] = in1[i] ^ in2[i];
+    }
+}
+
+static
+inline void bitsliced_m_vec_add(int m_legs, const uint32_t *in,
+                                uint32_t *acc) {
+    for (int i = 0; i < m_legs * 4; i++) {
+        acc[i] ^= in[i];
+    }
+}
+
+void bitsliced_m_upper(int m_legs, const uint32_t *in, uint32_t *out, int size);
+void bitsliced_m_vec_mul_add(int m_legs, const uint32_t *in, unsigned char a, uint32_t *acc);
+void bitslice_m_vec(int m_legs, const unsigned char *in, uint32_t *out);
+
+void unbitslice_m_vec(int m_legs, const uint32_t *in, unsigned char *out);
+
+void mul_add_bitsliced_m_upper_triangular_mat_x_mat(
+    int m_legs, const uint32_t *bs_mat, const unsigned char *mat, uint32_t *acc,
+    int bs_mat_rows, int bs_mat_cols, int mat_cols, int triangular);
+
+void mul_add_bitsliced_m_upper_triangular_mat_x_mat_trans(
+    int m_legs, const uint32_t *bs_mat, const unsigned char *mat, uint32_t *acc,
+    int bs_mat_rows, int bs_mat_cols, int mat_rows, int triangular);
+
+void mul_add_mat_trans_x_bitsliced_m_mat(int m_legs, const unsigned char *mat,
+        const uint32_t *bs_mat, uint32_t *acc,
+        int mat_rows, int mat_cols,
+        int bs_mat_cols);
+
+void mul_add_mat_x_bitsliced_m_mat(int m_legs, const unsigned char *mat,
+                                   const uint32_t *bs_mat, uint32_t *acc,
+                                   int mat_rows, int mat_cols, int bs_mat_cols);
+
+void bitsliced_m_calculate_PS(const uint32_t *P1, const uint32_t *P2,
+                              const uint32_t *P3, const unsigned char *S, int m,
+                              int v, int o, int k, uint32_t *PS);
+
+// Calculate SPS = S*P*S^T in Verify
+void bitsliced_m_calculate_PS_SPS(const uint32_t *P1, const uint32_t *P2, const uint32_t *P3, const unsigned char *S,
+                              const int m, const int v, const int o, const int k, uint32_t *SPS);
+
+
+void P1_times_O(const mayo_params_t* p, const uint32_t* P1, const unsigned char* O, uint32_t* acc);
+void P1P1t_times_O(const mayo_params_t* p, const uint32_t* P1, const unsigned char* O, uint32_t* acc);
+void P1_times_Vt(const mayo_params_t* p, const uint32_t* P1, const unsigned char* V, uint32_t* acc);
+
+int sample_solution(const mayo_params_t *p, unsigned char *A,
+                           const unsigned char *y, const unsigned char *r,
+                           unsigned char *x, int k, int o, int m, int A_cols);
+
+#endif

--- a/crypto_sign/mayo1/ref/bitsliced_arithmetic_128.h
+++ b/crypto_sign/mayo1/ref/bitsliced_arithmetic_128.h
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef BITSLICED_ARITHMETIC_128_H
+#define BITSLICED_ARITHMETIC_128_H
+
+#include <stdint.h>
+#include <mayo.h>
+
+// This implements arithmetic for bitsliced vectors of 128 field elements in Z_2[x]/(x^4+x+1)
+
+static
+inline void bitsliced_128_vec_copy(const uint64_t *in, uint64_t *out) {
+    out[0] = in[0];
+    out[1] = in[1];
+    out[2] = in[2];
+    out[3] = in[3];
+    out[4] = in[4];
+    out[5] = in[5];
+    out[6] = in[6];
+    out[7] = in[7];
+}
+
+static
+inline void bitsliced_128_vec_sum(const uint64_t *in1, const uint64_t *in2, uint64_t *out) {
+    out[0] = in1[0] ^ in2[0];
+    out[1] = in1[1] ^ in2[1];
+    out[2] = in1[2] ^ in2[2];
+    out[3] = in1[3] ^ in2[3];
+    out[4] = in1[4] ^ in2[4];
+    out[5] = in1[5] ^ in2[5];
+    out[6] = in1[6] ^ in2[6];
+    out[7] = in1[7] ^ in2[7];
+}
+
+static
+inline void bitsliced_128_vec_add(const uint64_t *in, uint64_t *acc) {
+    acc[0] ^= in[0];
+    acc[1] ^= in[1];
+    acc[2] ^= in[2];
+    acc[3] ^= in[3];
+    acc[4] ^= in[4];
+    acc[5] ^= in[5];
+    acc[6] ^= in[6];
+    acc[7] ^= in[7];
+}
+
+static 
+inline void bitsliced_128_vec_mul_add_x(const uint64_t *in, uint64_t *acc) {
+    acc[0] ^= in[6];
+    acc[1] ^= in[7];
+    acc[2] ^= in[0] ^ in[6];
+    acc[3] ^= in[1] ^ in[7];
+    acc[4] ^= in[2];
+    acc[5] ^= in[3];
+    acc[6] ^= in[4];
+    acc[7] ^= in[5];
+}
+
+static 
+inline void bitsliced_128_vec_mul_add_x_inv(const uint64_t *in, uint64_t *acc) {
+    acc[0] ^= in[2] ^ in[0];
+    acc[1] ^= in[3] ^ in[1];
+    acc[2] ^= in[4];
+    acc[3] ^= in[5];
+    acc[4] ^= in[6];
+    acc[5] ^= in[7];
+    acc[6] ^= in[0];
+    acc[7] ^= in[1];
+}
+
+static 
+inline void bitsliced_128_vec_mul_add(const uint64_t *in, unsigned char a, uint64_t *acc) {
+    // terms of a
+    uint64_t aa = a;
+    uint64_t a0 = -(aa & 1);
+    uint64_t a1 = -((aa >> 1) & 1);
+    uint64_t a2 = -((aa >> 2) & 1);
+    uint64_t a3 = -((aa >> 3) & 1);
+
+    uint64_t x[2], y[2], z[2];
+    // deg 0 term of a;
+    acc[0] ^= a0 & in[0];
+    acc[1] ^= a0 & in[1];
+    acc[2] ^= a0 & in[2];
+    acc[3] ^= a0 & in[3];
+    acc[4] ^= a0 & in[4];
+    acc[5] ^= a0 & in[5];
+    acc[6] ^= a0 & in[6];
+    acc[7] ^= a0 & in[7];
+
+    // deg 1 term of a;
+    x[0] = in[0] ^ in[6];
+    x[1] = in[1] ^ in[7];
+    acc[0] ^= a1 & in[6];
+    acc[1] ^= a1 & in[7];
+    acc[2] ^= a1 & x[0];
+    acc[3] ^= a1 & x[1];
+    acc[4] ^= a1 & in[2];
+    acc[5] ^= a1 & in[3];
+    acc[6] ^= a1 & in[4];
+    acc[7] ^= a1 & in[5];
+
+    // deg 2 term of a
+    y[0] = in[6] ^ in[4];
+    y[1] = in[7] ^ in[5];
+    acc[0] ^= a2 & in[4];
+    acc[1] ^= a2 & in[5];
+    acc[2] ^= a2 & y[0];
+    acc[3] ^= a2 & y[1];
+    acc[4] ^= a2 & x[0];
+    acc[5] ^= a2 & x[1];
+    acc[6] ^= a2 & in[2];
+    acc[7] ^= a2 & in[3];
+
+    // deg 3 term of a
+    z[0] = in[4] ^ in[2];
+    z[1] = in[5] ^ in[3];
+    acc[0] ^= a3 & in[2];
+    acc[1] ^= a3 & in[3];
+    acc[2] ^= a3 & z[0];
+    acc[3] ^= a3 & z[1];
+    acc[4] ^= a3 & y[0];
+    acc[5] ^= a3 & y[1];
+    acc[6] ^= a3 & x[0];
+    acc[7] ^= a3 & x[1];
+}
+
+static 
+inline void bitsliced_128_vec_mul_add_a(const uint64_t *in, uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3, uint64_t *acc) {
+
+    uint64_t x[2], y[2], z[2];
+    // deg 0 term of a;
+    acc[0] ^= a0 & in[0];
+    acc[1] ^= a0 & in[1];
+    acc[2] ^= a0 & in[2];
+    acc[3] ^= a0 & in[3];
+    acc[4] ^= a0 & in[4];
+    acc[5] ^= a0 & in[5];
+    acc[6] ^= a0 & in[6];
+    acc[7] ^= a0 & in[7];
+
+    // deg 1 term of a;
+    x[0] = in[0] ^ in[6];
+    x[1] = in[1] ^ in[7];
+    acc[0] ^= a1 & in[6];
+    acc[1] ^= a1 & in[7];
+    acc[2] ^= a1 & x[0];
+    acc[3] ^= a1 & x[1];
+    acc[4] ^= a1 & in[2];
+    acc[5] ^= a1 & in[3];
+    acc[6] ^= a1 & in[4];
+    acc[7] ^= a1 & in[5];
+
+    // deg 2 term of a
+    y[0] = in[6] ^ in[4];
+    y[1] = in[7] ^ in[5];
+    acc[0] ^= a2 & in[4];
+    acc[1] ^= a2 & in[5];
+    acc[2] ^= a2 & y[0];
+    acc[3] ^= a2 & y[1];
+    acc[4] ^= a2 & x[0];
+    acc[5] ^= a2 & x[1];
+    acc[6] ^= a2 & in[2];
+    acc[7] ^= a2 & in[3];
+
+    // deg 3 term of a
+    z[0] = in[4] ^ in[2];
+    z[1] = in[5] ^ in[3];
+    acc[0] ^= a3 & in[2];
+    acc[1] ^= a3 & in[3];
+    acc[2] ^= a3 & z[0];
+    acc[3] ^= a3 & z[1];
+    acc[4] ^= a3 & y[0];
+    acc[5] ^= a3 & y[1];
+    acc[6] ^= a3 & x[0];
+    acc[7] ^= a3 & x[1];
+}
+
+static 
+    inline void bitsliced_128_multiply_bins(uint32_t *bins_32, uint32_t *out_32) {
+
+    uint64_t *bins = (uint64_t *) bins_32;
+    uint64_t *out = (uint64_t *) out_32;
+
+    bitsliced_128_vec_mul_add_x_inv(bins +  5 * 8, bins +  10 * 8);
+    bitsliced_128_vec_mul_add_x(bins + 11 * 8, bins + 12 * 8);
+    bitsliced_128_vec_mul_add_x_inv(bins +  10 * 8, bins +  7 * 8);
+    bitsliced_128_vec_mul_add_x(bins + 12 * 8, bins +  6 * 8);
+    bitsliced_128_vec_mul_add_x_inv(bins +  7 * 8, bins +  14 * 8);
+    bitsliced_128_vec_mul_add_x(bins +  6 * 8, bins +  3 * 8);
+    bitsliced_128_vec_mul_add_x_inv(bins +  14 * 8, bins +  15 * 8);
+    bitsliced_128_vec_mul_add_x(bins +  3 * 8, bins +  8 * 8);
+    bitsliced_128_vec_mul_add_x_inv(bins +  15 * 8, bins +  13 * 8);
+    bitsliced_128_vec_mul_add_x(bins +  8 * 8, bins +  4 * 8);
+    bitsliced_128_vec_mul_add_x_inv(bins +  13 * 8, bins +  9 * 8);
+    bitsliced_128_vec_mul_add_x(bins +  4 * 8, bins +  2 * 8);
+    bitsliced_128_vec_mul_add_x_inv(bins +   9 * 8, bins +  1 * 8);
+    bitsliced_128_vec_mul_add_x(bins +  2 * 8, bins +  1 * 8);
+    bitsliced_128_vec_copy(bins + 8, out);
+}
+
+#endif

--- a/crypto_sign/mayo1/ref/bitsliced_arithmetic_64.h
+++ b/crypto_sign/mayo1/ref/bitsliced_arithmetic_64.h
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef BITSLICED_ARITHMETIC_64_H
+#define BITSLICED_ARITHMETIC_64_H
+
+#include <stdint.h>
+#include <mayo.h>
+
+// This implements arithmetic for bitsliced vectors of 64 field elements in Z_2[x]/(x^4+x+1)
+
+static
+inline void bitsliced_64_vec_copy(const uint64_t *in, uint64_t *out) {
+    out[0] = in[0];
+    out[1] = in[1];
+    out[2] = in[2];
+    out[3] = in[3];
+}
+
+static
+inline void bitsliced_64_vec_sum(const uint64_t *in1, const uint64_t *in2, uint64_t *out) {
+    out[0] = in1[0] ^ in2[0];
+    out[1] = in1[1] ^ in2[1];
+    out[2] = in1[2] ^ in2[2];
+    out[3] = in1[3] ^ in2[3];
+}
+
+static
+inline void bitsliced_64_vec_add(const uint64_t *in, uint64_t *acc) {
+    acc[0] ^= in[0];
+    acc[1] ^= in[1];
+    acc[2] ^= in[2];
+    acc[3] ^= in[3];
+}
+
+static 
+inline void bitsliced_64_vec_mul_add_x(const uint64_t *in, uint64_t *acc) {
+    acc[0] ^= in[3];
+    acc[1] ^= in[0] ^ in[3];
+    acc[2] ^= in[1];
+    acc[3] ^= in[2];
+}
+
+static 
+inline void bitsliced_64_vec_mul_add_x_inv(const uint64_t *in, uint64_t *acc) {
+    acc[0] ^= in[0] ^ in[1];
+    acc[1] ^= in[2];
+    acc[2] ^= in[3];
+    acc[3] ^= in[0];
+}
+
+static 
+inline void bitsliced_64_vec_mul_add(const uint64_t *in, unsigned char a, uint64_t *acc) {
+    // terms of a
+    uint64_t aa = a;
+    uint64_t a0 = -(aa & 1);
+    uint64_t a1 = -((aa >> 1) & 1);
+    uint64_t a2 = -((aa >> 2) & 1);
+    uint64_t a3 = -((aa >> 3) & 1);
+
+    uint64_t x, y, z;
+    // deg 0 term of a;
+    acc[0] ^= a0 & in[0];
+    acc[1] ^= a0 & in[1];
+    acc[2] ^= a0 & in[2];
+    acc[3] ^= a0 & in[3];
+
+    // deg 1 term of a;
+    x = in[0] ^ in[3];
+    acc[0] ^= a1 & in[3];
+    acc[1] ^= a1 & x;
+    acc[2] ^= a1 & in[1];
+    acc[3] ^= a1 & in[2];
+
+    // deg 2 term of a
+    y = in[3] ^ in[2];
+    acc[0] ^= a2 & in[2];
+    acc[1] ^= a2 & y;
+    acc[2] ^= a2 & x;
+    acc[3] ^= a2 & in[1];
+
+    // deg 3 term of a
+    z = in[2] ^ in[1];
+    acc[0] ^= a3 & in[1];
+    acc[1] ^= a3 & z;
+    acc[2] ^= a3 & y;
+    acc[3] ^= a3 & x;
+}
+
+static 
+inline void bitsliced_64_multiply_bins(uint32_t *bins_32, uint32_t *out_32) {
+
+    uint64_t *bins = (uint64_t *) bins_32;
+    uint64_t *out = (uint64_t *) out_32;
+
+    bitsliced_64_vec_mul_add_x_inv(bins +  5 * 4, bins +  10 * 4);
+    bitsliced_64_vec_mul_add_x(bins + 11 * 4, bins + 12 * 4);
+    bitsliced_64_vec_mul_add_x_inv(bins +  10 * 4, bins +  7 * 4);
+    bitsliced_64_vec_mul_add_x(bins + 12 * 4, bins +  6 * 4);
+    bitsliced_64_vec_mul_add_x_inv(bins +  7 * 4, bins +  14 * 4);
+    bitsliced_64_vec_mul_add_x(bins +  6 * 4, bins +  3 * 4);
+    bitsliced_64_vec_mul_add_x_inv(bins +  14 * 4, bins +  15 * 4);
+    bitsliced_64_vec_mul_add_x(bins +  3 * 4, bins +  8 * 4);
+    bitsliced_64_vec_mul_add_x_inv(bins +  15 * 4, bins +  13 * 4);
+    bitsliced_64_vec_mul_add_x(bins +  8 * 4, bins +  4 * 4);
+    bitsliced_64_vec_mul_add_x_inv(bins +  13 * 4, bins +  9 * 4);
+    bitsliced_64_vec_mul_add_x(bins +  4 * 4, bins +  2 * 4);
+    bitsliced_64_vec_mul_add_x_inv(bins +   9 * 4, bins +  1 * 4);
+    bitsliced_64_vec_mul_add_x(bins +  2 * 4, bins +  1 * 4);
+    bitsliced_64_vec_copy(bins + 4, out);
+}
+
+#endif

--- a/crypto_sign/mayo1/ref/bitsliced_arithmetic_96.h
+++ b/crypto_sign/mayo1/ref/bitsliced_arithmetic_96.h
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef BITSLICED_ARITHMETIC_96_H
+#define BITSLICED_ARITHMETIC_96_H
+
+#include <stdint.h>
+#include <mayo.h>
+
+// This implements arithmetic for bitsliced vectors of 96 field elements in Z_2[x]/(x^4+x+1)
+
+static
+inline void bitsliced_96_vec_copy(const uint32_t *in, uint32_t *out) {
+    out[0] = in[0];
+    out[1] = in[1];
+    out[2] = in[2];
+    out[3] = in[3];
+    out[4] = in[4];
+    out[5] = in[5];
+    out[6] = in[6];
+    out[7] = in[7];
+    out[8] = in[8];
+    out[9] = in[9];
+    out[10] = in[10];
+    out[11] = in[11];
+}
+
+static
+inline void bitsliced_96_vec_sum(const uint32_t *in1, const uint32_t *in2, uint32_t *out) {
+    out[0]  = in1[0] ^ in2[0];
+    out[1]  = in1[1] ^ in2[1];
+    out[2]  = in1[2] ^ in2[2];
+    out[3]  = in1[3] ^ in2[3];
+    out[4]  = in1[4] ^ in2[4];
+    out[5]  = in1[5] ^ in2[5];
+    out[6]  = in1[6] ^ in2[6];
+    out[7]  = in1[7] ^ in2[7];
+    out[8]  = in1[8] ^ in2[8];
+    out[9]  = in1[9] ^ in2[9];
+    out[10] = in1[10] ^ in2[10];
+    out[11] = in1[11] ^ in2[11];
+}
+
+static
+inline void bitsliced_96_vec_add(const uint32_t *in, uint32_t *acc) {
+    acc[0] ^= in[0];
+    acc[1] ^= in[1];
+    acc[2] ^= in[2];
+    acc[3] ^= in[3];
+    acc[4] ^= in[4];
+    acc[5] ^= in[5];
+    acc[6] ^= in[6];
+    acc[7] ^= in[7];
+    acc[8] ^= in[8];
+    acc[9] ^= in[9];
+    acc[10] ^= in[10];
+    acc[11] ^= in[11];
+}
+
+static 
+inline void bitsliced_96_vec_mul_add_x(const uint32_t *in, uint32_t *acc) {
+    acc[0]  ^= in[9];
+    acc[1]  ^= in[10];
+    acc[2]  ^= in[11];
+    acc[3]  ^= in[0] ^ in[9];
+
+    acc[4]  ^= in[1] ^ in[10];
+    acc[5]  ^= in[2] ^ in[11];
+    acc[6]  ^= in[3];
+    acc[7]  ^= in[4];
+    
+    acc[8]  ^= in[5];
+    acc[9]  ^= in[6];
+    acc[10] ^= in[7];
+    acc[11] ^= in[8];
+}
+
+static 
+inline void bitsliced_96_vec_mul_add_x_inv(const uint32_t *in, uint32_t *acc) {
+    acc[0]  ^= in[0] ^ in[3];
+    acc[1]  ^= in[1] ^ in[4];
+    acc[2]  ^= in[2] ^ in[5];
+    acc[3]  ^= in[6];
+    acc[4]  ^= in[7];
+    acc[5]  ^= in[8];
+    acc[6]  ^= in[9];
+    acc[7]  ^= in[10];
+    acc[8]  ^= in[11];
+    acc[9]  ^= in[0];
+    acc[10] ^= in[1];
+    acc[11] ^= in[2];
+}
+
+static 
+inline void bitsliced_96_vec_mul_add(const uint32_t *in, unsigned char a, uint32_t *acc) {
+    // terms of a
+    uint32_t aa = a;
+    uint32_t a0 = -(aa & 1);
+    uint32_t a1 = -((aa >> 1) & 1);
+    uint32_t a2 = -((aa >> 2) & 1);
+    uint32_t a3 = -((aa >> 3) & 1);
+
+    uint64_t x[3], y[3], z[3];
+    // deg 0 term of a;
+    acc[0]  ^= a0 & in[0];
+    acc[1]  ^= a0 & in[1];
+    acc[2]  ^= a0 & in[2];
+    acc[3]  ^= a0 & in[3];
+    acc[4]  ^= a0 & in[4];
+    acc[5]  ^= a0 & in[5];
+    acc[6]  ^= a0 & in[6];
+    acc[7]  ^= a0 & in[7];
+    acc[8]  ^= a0 & in[8];
+    acc[9]  ^= a0 & in[9];
+    acc[10] ^= a0 & in[10];
+    acc[11] ^= a0 & in[11];
+
+    // deg 1 term of a;
+    x[0] = in[0] ^ in[9];
+    x[1] = in[1] ^ in[10];
+    x[2] = in[2] ^ in[11];
+
+    acc[0]  ^= a1 & in[9];
+    acc[1]  ^= a1 & in[10];
+    acc[2]  ^= a1 & in[11];
+    acc[3]  ^= a1 & x[0];
+    acc[4]  ^= a1 & x[1];
+    acc[5]  ^= a1 & x[2];
+    acc[6]  ^= a1 & in[3];
+    acc[7]  ^= a1 & in[4];
+    acc[8]  ^= a1 & in[5];
+    acc[9]  ^= a1 & in[6];
+    acc[10] ^= a1 & in[7];
+    acc[11] ^= a1 & in[8];
+
+    // deg 2 term of a
+    y[0] = in[9] ^ in[6];
+    y[1] = in[10] ^ in[7];
+    y[2] = in[11] ^ in[8];
+
+    acc[0]  ^= a2 & in[6];
+    acc[1]  ^= a2 & in[7];
+    acc[2]  ^= a2 & in[8];
+    acc[3]  ^= a2 & y[0];
+    acc[4]  ^= a2 & y[1];
+    acc[5]  ^= a2 & y[2];
+    acc[6]  ^= a2 & x[0];
+    acc[7]  ^= a2 & x[1];
+    acc[8]  ^= a2 & x[2];
+    acc[9]  ^= a2 & in[3];
+    acc[10] ^= a2 & in[4];
+    acc[11] ^= a2 & in[5];
+
+    // deg 3 term of a
+    z[0] = in[6] ^ in[3];
+    z[1] = in[7] ^ in[4];
+    z[2] = in[8] ^ in[5];
+    acc[0]  ^= a3 & in[3];
+    acc[1]  ^= a3 & in[4];
+    acc[2]  ^= a3 & in[5];
+    acc[3]  ^= a3 & z[0];
+    acc[4]  ^= a3 & z[1];
+    acc[5]  ^= a3 & z[2];
+    acc[6]  ^= a3 & y[0];
+    acc[7]  ^= a3 & y[1];
+    acc[8]  ^= a3 & y[2];
+    acc[9]  ^= a3 & x[0];
+    acc[10] ^= a3 & x[1];
+    acc[11] ^= a3 & x[2];
+}
+
+static 
+inline void bitsliced_96_vec_mul_add_a(const uint32_t *in, uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3, uint32_t *acc) {
+    // terms of a
+    uint32_t x[3], y[3], z[3];
+    // deg 0 term of a;
+    acc[0]  ^= a0 & in[0];
+    acc[1]  ^= a0 & in[1];
+    acc[2]  ^= a0 & in[2];
+    acc[3]  ^= a0 & in[3];
+    acc[4]  ^= a0 & in[4];
+    acc[5]  ^= a0 & in[5];
+    acc[6]  ^= a0 & in[6];
+    acc[7]  ^= a0 & in[7];
+    acc[8]  ^= a0 & in[8];
+    acc[9]  ^= a0 & in[9];
+    acc[10] ^= a0 & in[10];
+    acc[11] ^= a0 & in[11];
+
+    // deg 1 term of a;
+    x[0] = in[0] ^ in[9];
+    x[1] = in[1] ^ in[10];
+    x[2] = in[2] ^ in[11];
+
+    acc[0]  ^= a1 & in[9];
+    acc[1]  ^= a1 & in[10];
+    acc[2]  ^= a1 & in[11];
+    acc[3]  ^= a1 & x[0];
+    acc[4]  ^= a1 & x[1];
+    acc[5]  ^= a1 & x[2];
+    acc[6]  ^= a1 & in[3];
+    acc[7]  ^= a1 & in[4];
+    acc[8]  ^= a1 & in[5];
+    acc[9]  ^= a1 & in[6];
+    acc[10] ^= a1 & in[7];
+    acc[11] ^= a1 & in[8];
+
+    // deg 2 term of a
+    y[0] = in[9] ^ in[6];
+    y[1] = in[10] ^ in[7];
+    y[2] = in[11] ^ in[8];
+
+    acc[0]  ^= a2 & in[6];
+    acc[1]  ^= a2 & in[7];
+    acc[2]  ^= a2 & in[8];
+    acc[3]  ^= a2 & y[0];
+    acc[4]  ^= a2 & y[1];
+    acc[5]  ^= a2 & y[2];
+    acc[6]  ^= a2 & x[0];
+    acc[7]  ^= a2 & x[1];
+    acc[8]  ^= a2 & x[2];
+    acc[9]  ^= a2 & in[3];
+    acc[10] ^= a2 & in[4];
+    acc[11] ^= a2 & in[5];
+
+    // deg 3 term of a
+    z[0] = in[6] ^ in[3];
+    z[1] = in[7] ^ in[4];
+    z[2] = in[8] ^ in[5];
+    acc[0]  ^= a3 & in[3];
+    acc[1]  ^= a3 & in[4];
+    acc[2]  ^= a3 & in[5];
+    acc[3]  ^= a3 & z[0];
+    acc[4]  ^= a3 & z[1];
+    acc[5]  ^= a3 & z[2];
+    acc[6]  ^= a3 & y[0];
+    acc[7]  ^= a3 & y[1];
+    acc[8]  ^= a3 & y[2];
+    acc[9]  ^= a3 & x[0];
+    acc[10] ^= a3 & x[1];
+    acc[11] ^= a3 & x[2];
+}
+
+static 
+inline void bitsliced_96_multiply_bins(uint32_t *bins, uint32_t *out) {
+
+    bitsliced_96_vec_mul_add_x_inv(bins +  5 * 12, bins +  10 * 12);
+    bitsliced_96_vec_mul_add_x(bins + 11 * 12, bins + 12 * 12);
+    bitsliced_96_vec_mul_add_x_inv(bins +  10 * 12, bins +  7 * 12);
+    bitsliced_96_vec_mul_add_x(bins + 12 * 12, bins +  6 * 12);
+    bitsliced_96_vec_mul_add_x_inv(bins +  7 * 12, bins +  14 * 12);
+    bitsliced_96_vec_mul_add_x(bins +  6 * 12, bins +  3 * 12);
+    bitsliced_96_vec_mul_add_x_inv(bins +  14 * 12, bins +  15 * 12);
+    bitsliced_96_vec_mul_add_x(bins +  3 * 12, bins +  8 * 12);
+    bitsliced_96_vec_mul_add_x_inv(bins +  15 * 12, bins +  13 * 12);
+    bitsliced_96_vec_mul_add_x(bins +  8 * 12, bins +  4 * 12);
+    bitsliced_96_vec_mul_add_x_inv(bins +  13 * 12, bins +  9 * 12);
+    bitsliced_96_vec_mul_add_x(bins +  4 * 12, bins +  2 * 12);
+    bitsliced_96_vec_mul_add_x_inv(bins +   9 * 12, bins +  1 * 12);
+    bitsliced_96_vec_mul_add_x(bins +  2 * 12, bins +  1 * 12);
+    bitsliced_96_vec_copy(bins + 12, out);
+}
+
+#endif

--- a/crypto_sign/mayo1/ref/debug_bench_tools.h
+++ b/crypto_sign/mayo1/ref/debug_bench_tools.h
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef DEBUG_BENCH_TOOLS_H
+#define DEBUG_BENCH_TOOLS_H
+
+
+#endif

--- a/crypto_sign/mayo1/ref/echelon_form.h
+++ b/crypto_sign/mayo1/ref/echelon_form.h
@@ -1,0 +1,179 @@
+
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ECHELON_FORM_H
+#define ECHELON_FORM_H
+
+#include <stdalign.h>
+#include <stdint.h>
+#include <mem.h>
+
+#define MAYO_MAX(x, y) (((x) > (y)) ? (x) : (y))
+#define MAYO_MIN(x, y) (((x) < (y)) ? (x) : (y))
+
+static inline unsigned char
+bitsliced_m_extract_element(int m_legs, const uint32_t *in, int index) {
+    const uint32_t *in0 = in;
+    const uint32_t *in1 = in + m_legs;
+    const uint32_t *in2 = in + 2 * m_legs;
+    const uint32_t *in3 = in + 3 * m_legs;
+    const int leg = index / 32;
+    // element order is 0, 8, 16, 24, 1, 9, 17, 25, 2, 10, 18, 26, ...
+    const int shift = ((index & 0x7) << 2) + ((index & 0x18) >> 3);
+
+    return ((in0[leg] >> shift) & 1) ^ (((in1[leg] >> shift) & 1) << 1) ^
+           (((in2[leg] >> shift) & 1) << 2) ^ (((in3[leg] >> shift) & 1) << 3);
+}
+
+static inline void
+ef_bitslice_m_vec(int m_legs, const unsigned char *in, uint32_t *out) {
+    uint32_t *out0 = out;
+    uint32_t *out1 = out + m_legs;
+    uint32_t *out2 = out + 2 * m_legs;
+    uint32_t *out3 = out + 3 * m_legs;
+
+
+    uint32_t in32[4];
+    for (int leg = 0; leg < m_legs; leg++) {
+        for(int i = 0; i < 4; i++) {
+            in32[i] = (in[32*leg + i*8 + 0] <<  0) ^ (in[32*leg + i*8 + 1] <<  4) ^ (in[32*leg + i*8 + 2] <<  8) ^ (in[32*leg + i*8 + 3] << 12) ^
+                      (in[32*leg + i*8 + 4] << 16) ^ (in[32*leg + i*8 + 5] << 20) ^ (in[32*leg + i*8 + 6] << 24) ^ (in[32*leg + i*8 + 7] << 28);
+        }
+        out0[leg] = ((in32[0] & 0x11111111) >> 0) ^ ((in32[1] & 0x11111111) << 1) ^ ((in32[2] & 0x11111111) << 2) ^ ((in32[3] & 0x11111111) << 3);
+        out1[leg] = ((in32[0] & 0x22222222) >> 1) ^ ((in32[1] & 0x22222222) >> 0) ^ ((in32[2] & 0x22222222) << 1) ^ ((in32[3] & 0x22222222) << 2);
+        out2[leg] = ((in32[0] & 0x44444444) >> 2) ^ ((in32[1] & 0x44444444) >> 1) ^ ((in32[2] & 0x44444444) >> 0) ^ ((in32[3] & 0x44444444) << 1);
+        out3[leg] = ((in32[0] & 0x88888888) >> 3) ^ ((in32[1] & 0x88888888) >> 2) ^ ((in32[2] & 0x88888888) >> 1) ^ ((in32[3] & 0x88888888) >> 0);
+    }
+}
+static inline void
+ef_unbitslice_m_vec(int m_legs, const uint32_t *in, unsigned char *out) {
+    const uint32_t *in0 = in;
+    const uint32_t *in1 = in + m_legs;
+    const uint32_t *in2 = in + 2 * m_legs;
+    const uint32_t *in3 = in + 3 * m_legs;
+
+    uint32_t out32[4];
+    for (int leg = 0; leg < m_legs; leg ++) {
+        out32[0] = ((in0[leg] & 0x11111111) >> 0) ^ ((in1[leg] & 0x11111111) << 1) ^ ((in2[leg] & 0x11111111) << 2) ^ ((in3[leg] & 0x11111111) << 3);
+        out32[1] = ((in0[leg] & 0x22222222) >> 1) ^ ((in1[leg] & 0x22222222) >> 0) ^ ((in2[leg] & 0x22222222) << 1) ^ ((in3[leg] & 0x22222222) << 2);
+        out32[2] = ((in0[leg] & 0x44444444) >> 2) ^ ((in1[leg] & 0x44444444) >> 1) ^ ((in2[leg] & 0x44444444) >> 0) ^ ((in3[leg] & 0x44444444) << 1);
+        out32[3] = ((in0[leg] & 0x88888888) >> 3) ^ ((in1[leg] & 0x88888888) >> 2) ^ ((in2[leg] & 0x88888888) >> 1) ^ ((in3[leg] & 0x88888888) >> 0);
+
+
+        for(int i = 0; i < 8; i++) {
+            out[32*leg + 0*8 + i] = (out32[0] >> (i*4)) & 0xF;
+            out[32*leg + 1*8 + i] = (out32[1] >> (i*4)) & 0xF;
+            out[32*leg + 2*8 + i] = (out32[2] >> (i*4)) & 0xF;
+            out[32*leg + 3*8 + i] = (out32[3] >> (i*4)) & 0xF;
+        }
+    }
+}
+
+// put matrix in row echelon form with ones on first nonzero entries *in
+// constant time*
+static inline void EF(unsigned char *A, int nrows, int ncols) {
+
+    alignas (32) uint32_t _pivot_row[(K_MAX * O_MAX + 1 + 31) / 32 * 4];
+    alignas (32) uint32_t _pivot_row2[(K_MAX * O_MAX + 1 + 31) / 32 * 4];
+    alignas (32) uint32_t bitsliced_A[((K_MAX * O_MAX + 1 + 31) / 32) * 4 * M_MAX];
+
+    int legs = (ncols + 31) / 32;
+
+    // bitslice the matrix A
+    for (int i = 0; i < nrows; i++) {
+        ef_bitslice_m_vec(legs, A + i * ncols, bitsliced_A + i * legs * 4);
+    }
+
+    // pivot row is secret, pivot col is not
+
+    unsigned char inverse;
+    int pivot_row = 0;
+    for (int pivot_col = 0; pivot_col < ncols; pivot_col++) {
+
+        int pivot_row_lower_bound = MAYO_MAX(0, pivot_col + nrows - ncols);
+        int pivot_row_upper_bound = MAYO_MIN(nrows - 1, pivot_col);
+        // the pivot row is guaranteed to be between these lower and upper bounds if
+        // A has full rank
+
+        // zero out pivot row
+        for (int i = 0; i < legs * 4; i++) {
+            _pivot_row[i] = 0;
+            _pivot_row2[i] = 0;
+        }
+
+        // try to get a pivot row in constant time
+        unsigned char pivot = 0;
+        uint32_t pivot_is_zero = -1;
+        for (int row = pivot_row_lower_bound;
+                row <= MAYO_MIN(nrows - 1, pivot_row_upper_bound + 32); row++) {
+
+            uint32_t is_pivot_row = ~ct_compare_32(row, pivot_row);
+            uint32_t below_pivot_row = ct_is_greater_than(row, pivot_row);
+
+            for (int j = 0; j < legs * 4; j++) {
+                _pivot_row[j] ^= (is_pivot_row | (below_pivot_row & pivot_is_zero)) &
+                                 bitsliced_A[row * legs * 4 + j];
+            }
+            pivot = bitsliced_m_extract_element(legs, _pivot_row, pivot_col);
+            pivot_is_zero = ~ct_compare_32((int) pivot, 0);
+        }
+
+        // multiply pivot row by inverse of pivot
+        inverse = inverse_f(pivot);
+#if defined(MAYO_VARIANT) && (((K_MAX * O_MAX + 1 + 31) / 32) == 3)
+        bitsliced_96_vec_mul_add(_pivot_row, inverse, _pivot_row2);
+#else
+        bitsliced_m_vec_mul_add(legs, _pivot_row, inverse, _pivot_row2);
+#endif
+
+        // conditionally write pivot row to the correct row, if there is a nonzero
+        // pivot
+        for (int row = pivot_row_lower_bound; row <= pivot_row_upper_bound; row++) {
+            uint32_t do_copy = ~ct_compare_32(row, pivot_row) & ~pivot_is_zero;
+            uint32_t do_not_copy = ~do_copy;
+            for (int col = 0; col < legs * 4; col++) {
+                bitsliced_A[row * legs * 4 + col] =
+                    (do_not_copy & bitsliced_A[row * legs * 4 + col]) +
+                    (do_copy & _pivot_row2[col]);
+            }
+        }
+
+        // eliminate entries below pivot
+        for (int row = pivot_row_lower_bound; row < nrows; row++) {
+            unsigned char below_pivot = (unsigned char) (ct_is_greater_than(row, pivot_row) & ~pivot_is_zero);
+            unsigned char elt_to_elim = bitsliced_m_extract_element(
+                                            legs, bitsliced_A + row * legs * 4, pivot_col);
+
+#if defined(MAYO_VARIANT) && (((K_MAX * O_MAX + 1 + 31) / 32) == 3)
+            bitsliced_96_vec_mul_add(_pivot_row2, below_pivot & elt_to_elim,
+                                    bitsliced_A + row * legs * 4);
+#elif defined(MAYO_VARIANT) && (((K_MAX * O_MAX + 1 + 31) / 32) == 4)
+            bitsliced_128_vec_mul_add((uint64_t *)_pivot_row2, below_pivot & elt_to_elim,
+                                    (uint64_t *)(bitsliced_A + row * legs * 4));                                    
+#else
+            bitsliced_m_vec_mul_add(legs, _pivot_row2, below_pivot & elt_to_elim,
+                                    bitsliced_A + row * legs * 4);
+
+#endif
+                            
+        }
+
+        pivot_row += (-(int32_t)(~pivot_is_zero));
+    }
+
+    unsigned char temp[(O_MAX * K_MAX + 1 + 32) * 100];
+
+    // unbitslice the matrix A
+    for (int i = 0; i < nrows; i++) {
+        ef_unbitslice_m_vec(legs, bitsliced_A + i * legs * 4, temp);
+        for (int j = 0; j < ncols; j++) {
+            A[i * ncols + j] = temp[j];
+        }
+    }
+
+    mayo_secure_clear(temp, K_MAX * O_MAX + 1 + 32);
+    mayo_secure_clear(_pivot_row, (K_MAX * O_MAX + 1 + 31) / 32 * 4 * 4);
+    mayo_secure_clear(_pivot_row2, (K_MAX * O_MAX + 1 + 31) / 32 * 4 * 4);
+}
+
+#endif

--- a/crypto_sign/mayo1/ref/mayo.c
+++ b/crypto_sign/mayo1/ref/mayo.c
@@ -1,0 +1,553 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <mem.h>
+#include <mayo.h>
+#include <rng.h>
+#include <aes_ctr.h>
+#include <bitsliced_arithmetic.h>
+#include <simple_arithmetic.h>
+#include <fips202.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdalign.h>
+#ifdef ENABLE_CT_TESTING
+#include <valgrind/memcheck.h>
+#endif
+
+#define PK_PRF AES_128_CTR
+#define TICTOC
+#include <debug_bench_tools.h>
+
+static void decode(const unsigned char *m, unsigned char *mdec, int mdeclen) {
+    int i;
+    for (i = 0; i < mdeclen / 2; ++i) {
+        *mdec++ = m[i] & 0xf;
+        *mdec++ = m[i] >> 4;
+    }
+
+    if (mdeclen % 2 == 1) {
+        *mdec++ = m[i] & 0x0f;
+    }
+}
+
+static void encode(const unsigned char *m, unsigned char *menc, int mlen) {
+    int i;
+    for (i = 0; i < mlen / 2; ++i, m += 2) {
+        menc[i] = (*m) | (*(m + 1) << 4);
+    }
+
+    if (mlen % 2 == 1) {
+        menc[i] = (*m);
+    }
+}
+
+static void reduce_y_mod_fX(unsigned char *y, int m, int k,
+                            const unsigned char *ftail) {
+    for (int i = m + k * (k + 1) / 2 - 2; i >= m; i--) {
+        for (int j = 0; j < F_TAIL_LEN; j++) {
+            y[i - m + j] ^= mul_f(y[i], ftail[j]);
+        }
+        y[i] = 0;
+    }
+}
+
+static void reduce_A_mod_fX(unsigned char *A, int m, int k, int A_cols,
+                            const unsigned char *ftail) {
+    for (int i = m + k * (k + 1) / 2 - 2; i >= m; i--) {
+        for (int kk = 0; kk < A_cols - 1; kk++) {
+            for (int j = 0; j < F_TAIL_LEN; j++) {
+                A[(i - m + j) * A_cols + kk] ^= mul_f(A[i * A_cols + kk], ftail[j]);
+            }
+            A[i * A_cols + kk] = 0;
+        }
+    }
+}
+
+#define MAYO_POSITION_IN_UPPER_TRIAGONAL_MATRIX(i, j, size)                    \
+  (i * size + j - (i * (i + 1) / 2))
+
+
+// Public API
+
+int mayo_keypair(const mayo_params_t *p, unsigned char *pk, unsigned char *sk) {
+    int ret = 0;
+
+    ret = mayo_keypair_compact(p, pk, sk);
+    if (ret != MAYO_OK) {
+        goto err;
+    }
+
+err:
+    return ret;
+}
+
+int mayo_sign(const mayo_params_t *p, unsigned char *sm,
+              unsigned long long *smlen, const unsigned char *m,
+              unsigned long long mlen, const unsigned char *csk) {
+    int ret = MAYO_OK;
+    unsigned char tenc[M_BYTES_MAX], t[M_MAX]; // no secret data
+    unsigned char y[2 * M_MAX] = {
+        0
+    }; // 2*m entries to allow for lazy reduction mod f(X) // no secret data
+    unsigned char salt[SALT_BYTES_MAX]; // not secret data
+    unsigned char V[K_MAX * V_BYTES_MAX + R_BYTES_MAX],
+             Vdec[N_MINUS_O_MAX * K_MAX];              // secret data
+    unsigned char M[M_MAX * O_MAX * K_MAX] = {0}; // secret data
+    unsigned char A[2 * M_MAX * (K_MAX * O_MAX + 1)] = {
+        0
+    }; // make room for 2m rows to allow for lazy reduction mod f(X) //
+    // secret data
+    unsigned char x[K_MAX * N_MAX];     // not secret data
+    unsigned char r[K_MAX * O_MAX + 1] = { 0 }; // secret data
+    unsigned char s[K_MAX * N_MAX];     // not secret data
+    const unsigned char *seed_sk;
+    unsigned char O[(N_MINUS_O_MAX)*O_MAX]; // secret data
+    alignas(32) sk_t sk;                    // secret data
+
+    unsigned char Ox[N_MINUS_O_MAX];        // secret data
+    // unsigned char Mdigest[DIGEST_BYTES];
+    unsigned char tmp[DIGEST_BYTES_MAX + SALT_BYTES_MAX + SK_SEED_BYTES_MAX + 1];
+    unsigned char *ctrbyte;
+    unsigned char *vi;
+    unsigned char *Mi, *Mj;
+
+    const int param_m = PARAM_m(p);
+    const int param_n = PARAM_n(p);
+    const int param_o = PARAM_o(p);
+    const int param_k = PARAM_k(p);
+    const int param_m_bytes = PARAM_m_bytes(p);
+    const int param_v_bytes = PARAM_v_bytes(p);
+    const int param_r_bytes = PARAM_r_bytes(p);
+    const int param_P1_bytes = PARAM_P1_bytes(p);
+    const int param_sig_bytes = PARAM_sig_bytes(p);
+    const int param_A_cols = PARAM_A_cols(p);
+    const int param_digest_bytes = PARAM_digest_bytes(p);
+    const int param_sk_seed_bytes = PARAM_sk_seed_bytes(p);
+    const int param_salt_bytes = PARAM_salt_bytes(p);
+
+    ret = mayo_expand_sk(p, csk, &sk);
+    if (ret != MAYO_OK) {
+        goto err;
+    }
+
+    seed_sk = csk;
+    decode(sk.o, O, (param_n - param_o) * param_o);
+
+    // hash message
+    shake256(tmp, param_digest_bytes, m, mlen);
+
+    uint32_t *bitsliced_P1 = sk.p;
+    uint32_t *bitsliced_L = sk.p + (param_P1_bytes/4);
+    uint32_t bitsliced_M[K_MAX * O_MAX * M_MAX / 8] = {0};
+
+#ifdef TARGET_BIG_ENDIAN
+    for (int i = 0; i < param_P1_bytes / 4; ++i) {
+        bitsliced_P1[i] = BSWAP32(bitsliced_P1[i]);
+    }
+    for (int i = 0; i < param_P2_bytes / 4; ++i) {
+        bitsliced_L[i] = BSWAP32(bitsliced_L[i]);
+    }
+#endif
+
+    // choose the randomizer
+    if (randombytes(tmp + param_digest_bytes, param_salt_bytes) != MAYO_OK) {
+        ret = MAYO_ERR;
+        goto err;
+    }
+
+    // hashing to salt
+    memcpy(tmp + param_digest_bytes + param_salt_bytes, seed_sk,
+           param_sk_seed_bytes);
+    shake256(salt, param_salt_bytes, tmp,
+             param_digest_bytes + param_salt_bytes + param_sk_seed_bytes);
+
+#ifdef ENABLE_CT_TESTING
+    VALGRIND_MAKE_MEM_DEFINED(salt, SALT_BYTES_MAX); // Salt is not secret
+#endif
+
+    // hashing to t
+    memcpy(tmp + param_digest_bytes, salt, param_salt_bytes);
+    ctrbyte = tmp + param_digest_bytes + param_salt_bytes + param_sk_seed_bytes;
+
+    shake256(tenc, param_m_bytes, tmp, param_digest_bytes + param_salt_bytes);
+    decode(tenc, t, param_m); // may not be necessary
+
+    for (int ctr = 0; ctr <= 255; ++ctr) {
+        *ctrbyte = (unsigned char)ctr;
+
+        shake256(V, param_k * param_v_bytes + param_r_bytes, tmp,
+                 param_digest_bytes + param_salt_bytes + param_sk_seed_bytes + 1);
+
+        // decode the v_i vectors
+        for (int i = 0; i <= param_k - 1; ++i) {
+            decode(V + i * param_v_bytes, Vdec + i * (param_n - param_o),
+                   param_n - param_o);
+        }
+
+        // compute all the v_i^T * L matrices.
+        mul_add_mat_x_bitsliced_m_mat(param_m / 32, Vdec, bitsliced_L, bitsliced_M,
+                                      param_k, param_n - param_o, param_o);
+
+        // move the Mi from bitsliced to "standard" representation
+        for (int i = 0; i < param_k; i++) {
+            Mi = M + i * param_m * param_o;
+            // unbitslice Mi one column at a time
+            unsigned char temp_Mi_col[M_MAX];
+            for (int j = 0; j < param_o; j++) {
+                unbitslice_m_vec(param_m / 32,
+                                 bitsliced_M + (param_m / 8) * (i * param_o + j),
+                                 temp_Mi_col);
+                for (int k = 0; k < param_m; k++) {
+                    *(Mi + k * param_o + j) = temp_Mi_col[k];
+                }
+            }
+        }
+
+        memset(A, 0, 2 * param_m * param_A_cols);
+        memcpy(y, t, param_m);
+
+        // compute all the v_i^t * P^(1) * v_j
+        alignas (32) uint32_t bitsliced_Pv[N_MINUS_O_MAX * K_MAX * M_MAX / 8] = {0};
+        alignas (32) uint32_t bitsliced_vPv[K_MAX * K_MAX * M_MAX / 8] = {0};
+        P1_times_Vt(p, bitsliced_P1, Vdec, bitsliced_Pv);
+        mul_add_mat_x_bitsliced_m_mat(param_m / 32, Vdec, bitsliced_Pv,
+                                      bitsliced_vPv, param_k, param_n - param_o,
+                                      param_k);
+
+        alignas (32) uint32_t bitsliced_vPv_upper[K_MAX * (K_MAX + 1) / 2 * M_MAX / 8];
+        bitsliced_m_upper(param_m / 32, bitsliced_vPv, bitsliced_vPv_upper,
+                          param_k);
+
+        int l = 0;
+        for (int i = 0; i <= param_k - 1; ++i) {
+            for (int j = param_k - 1; j >= i; --j) {
+                int pos = MAYO_POSITION_IN_UPPER_TRIAGONAL_MATRIX(i, j, param_k);
+                // unbitslice the vPV and subtract from to y, shifted "down" by l
+                // positions
+                unsigned char temp_y[M_MAX];
+                unbitslice_m_vec(param_m / 32,
+                                 bitsliced_vPv_upper + pos * (param_m / 8), temp_y);
+                for (int k = 0; k < param_m; k++) {
+                    y[l + k] ^= temp_y[k];
+                }
+
+                // add the M_i and M_j to A, shifted "down" by l positions
+                Mj = M + j * param_m * param_o;
+                for (int rr = 0; rr < param_m; rr++) {
+                    for (int c = 0; c < param_o; c++) {
+                        A[(rr + l) * param_A_cols + i * param_o + c] ^= Mj[rr * param_o + c];
+                    }
+                }
+
+                if (i != j) {
+                    Mi = M + i * param_m * param_o;
+                    for (int rr = 0; rr < param_m; rr++) {
+                        for (int c = 0; c < param_o; c++) {
+                            A[(rr + l) * param_A_cols + j * param_o + c] ^=
+                                Mi[rr * param_o + c];
+                        }
+                    }
+                }
+                l++;
+            }
+        }
+
+        // reduce y and A mod f(X)
+        reduce_y_mod_fX(y, param_m, param_k, PARAM_f_tail(p));
+        reduce_A_mod_fX(A, param_m, param_k, param_A_cols, PARAM_f_tail(p));
+
+        decode(V + param_k * param_v_bytes, r,
+               param_k *
+               param_o);
+        if (sample_solution(p, A, y, r, x, param_k, param_o, param_m, param_A_cols)) {
+            break;
+        } else {
+            memset(bitsliced_M, 0, param_k * param_o * param_m / 8 * sizeof(uint32_t));
+        }
+    }
+
+    // s is already 0
+    for (int i = 0; i <= param_k - 1; ++i) {
+        vi = Vdec + i * (param_n - param_o);
+        mat_mul(O, x + i * param_o, Ox, param_o, param_n - param_o, 1);
+        mat_add(vi, Ox, s + i * param_n, param_n - param_o, 1);
+        memcpy(s + i * param_n + (param_n - param_o), x + i * param_o, param_o);
+    }
+
+    encode(s, sm, param_n * param_k);
+    memcpy(sm + param_sig_bytes - param_salt_bytes, salt, param_salt_bytes);
+    memmove(sm + param_sig_bytes, m,
+           mlen); // assert: smlen == param_k * param_n + mlen
+    *smlen = param_sig_bytes + mlen;
+
+err:
+    mayo_secure_clear(V, K_MAX * V_BYTES_MAX + R_BYTES_MAX);
+    mayo_secure_clear(Vdec, N_MINUS_O_MAX * K_MAX);
+    mayo_secure_clear(M, M_MAX * O_MAX * K_MAX);
+    mayo_secure_clear(A, 2 * M_MAX * (K_MAX * O_MAX + 1));
+    mayo_secure_clear(r, K_MAX * O_MAX + 1);
+    mayo_secure_clear(O, (N_MINUS_O_MAX)*O_MAX);
+    mayo_secure_clear(&sk, sizeof(sk_t));
+    mayo_secure_clear(Ox, N_MINUS_O_MAX);
+    mayo_secure_clear(tmp,
+                      DIGEST_BYTES_MAX + SALT_BYTES_MAX + SK_SEED_BYTES_MAX + 1);
+    return ret;
+}
+
+int mayo_open(const mayo_params_t *p, unsigned char *m,
+              unsigned long long *mlen, const unsigned char *sm,
+              unsigned long long smlen, const unsigned char *pk) {
+    const int param_sig_bytes = PARAM_sig_bytes(p);
+    if (smlen < (unsigned long long)param_sig_bytes) {
+        return MAYO_ERR;
+    }
+    int result = mayo_verify(p, sm + param_sig_bytes, smlen - param_sig_bytes, sm,
+                             pk);
+
+    if (result == MAYO_OK) {
+        *mlen = smlen - param_sig_bytes;
+        memmove(m, sm + param_sig_bytes, *mlen);
+    }
+
+    return result;
+}
+
+int mayo_keypair_compact(const mayo_params_t *p, unsigned char *cpk,
+                         unsigned char *csk) {
+    int ret = MAYO_OK;
+    unsigned char *seed_sk = csk;
+    unsigned char S[PK_SEED_BYTES_MAX + O_BYTES_MAX];
+    alignas (32) uint32_t bitsliced_P[(P1_BYTES_MAX + P2_BYTES_MAX) / 4];
+    alignas (32) uint32_t bitsliced_P3[O_MAX * O_MAX * M_MAX / 8] = {0};
+    alignas (32) uint32_t bitsliced_P3_upper[P3_BYTES_MAX / 4];
+    unsigned char *seed_pk;
+    unsigned char O[(N_MINUS_O_MAX)*O_MAX];
+
+    const int param_m = PARAM_m(p);
+    const int param_v = PARAM_v(p);
+    const int param_o = PARAM_o(p);
+    const int param_O_bytes = PARAM_O_bytes(p);
+    const int param_P1_bytes = PARAM_P1_bytes(p);
+    const int param_P2_bytes = PARAM_P2_bytes(p);
+    const int param_P3_bytes = PARAM_P3_bytes(p);
+    const int param_pk_seed_bytes = PARAM_pk_seed_bytes(p);
+    const int param_sk_seed_bytes = PARAM_sk_seed_bytes(p);
+
+    // seed_sk $←- B^(sk_seed bytes)
+    if (randombytes(seed_sk, param_sk_seed_bytes) != MAYO_OK) {
+        ret = MAYO_ERR;
+        goto err;
+    }
+
+    // S ← shake256(seedsk, pk seed bytes + O bytes)
+    shake256(S, param_pk_seed_bytes + param_O_bytes, seed_sk,
+             param_sk_seed_bytes);
+    // seed_pk ← s[0 : pk_seed_bytes]
+    seed_pk = S;
+
+    // o ← Decode_o(s[pk_seed_bytes : pk_seed_bytes + o_bytes])
+    decode(S + param_pk_seed_bytes, O, param_v * param_o);
+
+#ifdef ENABLE_CT_TESTING
+    VALGRIND_MAKE_MEM_DEFINED(seed_pk, param_pk_seed_bytes);
+#endif
+
+    // encode decode not necessary, since P1,P2 and P3 are sampled and stored in
+    // bit-sliced format.
+    PK_PRF((unsigned char *)bitsliced_P, param_P1_bytes + param_P2_bytes, seed_pk,
+           param_pk_seed_bytes);
+
+    uint32_t *bitsliced_P1 = bitsliced_P;
+    uint32_t *bitsliced_P2 = bitsliced_P + (param_P1_bytes / 4);
+
+    int m_legs = param_m / 32;
+
+    // compute P1*O + P2 in position of P2
+    uint32_t *bitsliced_P1O_P2 = bitsliced_P2;
+    P1_times_O(p, bitsliced_P1, O, bitsliced_P1O_P2);
+
+    // compute P3 = O^t * (P1*O + P2)
+    mul_add_mat_trans_x_bitsliced_m_mat(m_legs, O, bitsliced_P1O_P2, bitsliced_P3,
+                                        param_v, param_o, param_o);
+
+    // store seed_pk in cpk
+    memcpy(cpk, seed_pk, param_pk_seed_bytes);
+
+    // compute Upper(P3) and store in cpk
+    bitsliced_m_upper(
+        m_legs, bitsliced_P3, bitsliced_P3_upper,
+        param_o);
+
+    memcpy(cpk + param_pk_seed_bytes, bitsliced_P3_upper, param_P3_bytes);
+
+err:
+    mayo_secure_clear(O, (N_MINUS_O_MAX)*O_MAX);
+    mayo_secure_clear(bitsliced_P3, O_MAX * O_MAX * M_MAX / 2);
+    return ret;
+}
+
+int mayo_expand_pk(const mayo_params_t *p, const unsigned char *cpk,
+                   unsigned char *pk) {
+    #ifdef MAYO_VARIANT
+    (void)p;
+    #endif
+    const int param_P1_bytes = PARAM_P1_bytes(p);
+    const int param_P2_bytes = PARAM_P2_bytes(p);
+    const int param_P3_bytes = PARAM_P3_bytes(p);
+    const int param_pk_seed_bytes = PARAM_pk_seed_bytes(p);
+    PK_PRF(pk, param_P1_bytes + param_P2_bytes, cpk, param_pk_seed_bytes);
+    pk += param_P1_bytes + param_P2_bytes;
+    memmove(pk, cpk + param_pk_seed_bytes, param_P3_bytes);
+    return MAYO_OK;
+}
+
+int mayo_expand_sk(const mayo_params_t *p, const unsigned char *csk,
+                   sk_t *sk) {
+    int ret = MAYO_OK;
+    unsigned char S[PK_SEED_BYTES_MAX + O_BYTES_MAX];
+    uint32_t *bitsliced_P = sk->p;
+    unsigned char O[(N_MINUS_O_MAX)*O_MAX];
+
+    const int param_o = PARAM_o(p);
+    const int param_v = PARAM_v(p);
+    const int param_O_bytes = PARAM_O_bytes(p);
+    const int param_P1_bytes = PARAM_P1_bytes(p);
+    const int param_P2_bytes = PARAM_P2_bytes(p);
+    const int param_pk_seed_bytes = PARAM_pk_seed_bytes(p);
+    const int param_sk_seed_bytes = PARAM_sk_seed_bytes(p);
+
+    const unsigned char *seed_sk = csk;
+    unsigned char *seed_pk = S;
+
+    shake256(S, param_pk_seed_bytes + param_O_bytes, seed_sk,
+             param_sk_seed_bytes);
+    decode(S + param_pk_seed_bytes, O,
+           param_v * param_o); // O = S + PK_SEED_BYTES;
+
+#ifdef ENABLE_CT_TESTING
+    VALGRIND_MAKE_MEM_DEFINED(seed_pk, param_pk_seed_bytes);
+#endif
+
+    // encode decode not necessary, since P1,P2 and P3 are sampled and stored in
+    // bitsliced format.
+    PK_PRF((unsigned char *)bitsliced_P, param_P1_bytes + param_P2_bytes, seed_pk,
+           param_pk_seed_bytes);
+
+    uint32_t *bitsliced_P1 = bitsliced_P;
+    uint32_t *bitsliced_P2 = bitsliced_P + (param_P1_bytes / 4);
+
+#ifdef TARGET_BIG_ENDIAN
+    for (int i = 0; i < (param_P1_bytes + param_P2_bytes) / 4; ++i) {
+        bitsliced_P[i] = BSWAP32(bitsliced_P[i]);
+    }
+#endif
+
+    // compute L_i = (P1 + P1^t)*O + P2
+    uint32_t *bitsliced_L = bitsliced_P2;
+
+    P1P1t_times_O(p, bitsliced_P1, O, bitsliced_L);
+
+    // write to sk
+    memcpy(sk->o, S + param_pk_seed_bytes, param_O_bytes);
+
+#ifdef TARGET_BIG_ENDIAN
+    for (int i = 0; i < (param_P1_bytes + param_P2_bytes) / 4; ++i) {
+        bitsliced_P[i] = BSWAP32(bitsliced_P[i]);
+    }
+#endif
+
+    mayo_secure_clear(S, PK_SEED_BYTES_MAX + O_BYTES_MAX);
+    mayo_secure_clear(O, (N_MINUS_O_MAX)*O_MAX);
+    return ret;
+}
+
+int mayo_verify(const mayo_params_t *p, const unsigned char *m,
+                unsigned long long mlen, const unsigned char *sig,
+                const unsigned char *cpk) {
+
+    unsigned char tEnc[M_BYTES_MAX];
+    unsigned char t[M_MAX];
+    unsigned char y[2 * M_MAX] = {0}; // extra space for reduction mod f(X)
+    unsigned char s[K_MAX * N_MAX];
+    alignas (64) uint32_t pk[EPK_BYTES_MAX / 4];
+    unsigned char tmp[DIGEST_BYTES_MAX + SALT_BYTES_MAX];
+
+    const int param_m = PARAM_m(p);
+    const int param_n = PARAM_n(p);
+    const int param_v = PARAM_v(p);
+    const int param_o = PARAM_o(p);
+    const int param_k = PARAM_k(p);
+    const int param_m_bytes = PARAM_m_bytes(p);
+    const int param_P1_bytes = PARAM_P1_bytes(p);
+    const int param_P2_bytes = PARAM_P2_bytes(p);
+#ifdef TARGET_BIG_ENDIAN
+    const int param_P3_bytes = PARAM_P3_bytes(p);
+#endif
+    const int param_sig_bytes = PARAM_sig_bytes(p);
+    const int param_digest_bytes = PARAM_digest_bytes(p);
+    const int param_salt_bytes = PARAM_salt_bytes(p);
+    const int m_legs = param_m / 32;
+
+    int ret = mayo_expand_pk(p, cpk, (unsigned char *)pk);
+    if (ret != MAYO_OK) {
+        return MAYO_ERR;
+    }
+
+    uint32_t *bitsliced_P1 = pk;
+    uint32_t *bitsliced_P2 = pk + (param_P1_bytes / 4);
+    uint32_t *bitsliced_P3 = bitsliced_P2 + (param_P2_bytes / 4);
+
+#ifdef TARGET_BIG_ENDIAN
+    for (int i = 0; i < param_P1_bytes / 4; ++i) {
+        bitsliced_P1[i] = BSWAP32(bitsliced_P1[i]);
+    }
+    for (int i = 0; i < param_P2_bytes / 4; ++i) {
+        bitsliced_P2[i] = BSWAP32(bitsliced_P2[i]);
+    }
+    for (int i = 0; i < param_P3_bytes / 4; ++i) {
+        bitsliced_P3[i] = BSWAP32(bitsliced_P3[i]);
+    }
+#endif
+
+    // hash m
+    shake256(tmp, param_digest_bytes, m, mlen);
+
+    // compute t
+    memcpy(tmp + param_digest_bytes, sig + param_sig_bytes - param_salt_bytes,
+           param_salt_bytes);
+    shake256(tEnc, param_m_bytes, tmp, param_digest_bytes + param_salt_bytes);
+    decode(tEnc, t, param_m);
+
+    // decode s
+    decode(sig, s, param_k * param_n);
+
+    // compute S * P * S = S* (P*S)
+    alignas (32) uint32_t bitsliced_SPS[K_MAX * K_MAX * M_MAX / 8] = {0};
+    bitsliced_m_calculate_PS_SPS(bitsliced_P1, bitsliced_P2, bitsliced_P3, s, param_m,
+                             param_v, param_o, param_k, bitsliced_SPS);
+
+    // compute SPS_upper
+    alignas (32) uint32_t bitsliced_SPS_upper[K_MAX * (K_MAX + 1) * M_MAX / 16];
+    bitsliced_m_upper(m_legs, bitsliced_SPS, bitsliced_SPS_upper, param_k);
+
+    int l = 0;
+    for (int i = 0; i < param_k; i++) {
+        for (int j = param_k - 1; j >= i; j--) {
+            int pos = MAYO_POSITION_IN_UPPER_TRIAGONAL_MATRIX(i, j, param_k);
+            // unbitslice SPS_upper and add to y, shifted "down" by l positions
+            unsigned char temp_y[M_MAX];
+            unbitslice_m_vec(m_legs, bitsliced_SPS_upper + pos * m_legs * 4, temp_y);
+            for (int k = 0; k < param_m; k++) {
+                y[l + k] ^= temp_y[k];
+            }
+            l++;
+        }
+    }
+
+    reduce_y_mod_fX(y, param_m, param_k, PARAM_f_tail(p));
+
+    if (memcmp(y, t, param_m) == 0) {
+        return MAYO_OK; // good signature
+    }
+    return MAYO_ERR; // bad signature
+}

--- a/crypto_sign/mayo1/ref/mayo.h
+++ b/crypto_sign/mayo1/ref/mayo.h
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef MAYO_H
+#define MAYO_H
+
+#define MAYO_VARIANT MAYO_1
+#ifndef PQM4
+#define PQM4
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define F_TAIL_LEN 5
+#define F_TAIL_64                                                              \
+  { 8, 0, 2, 8, 0 } // f(z) =  z^64         + x^3*z^3 + x*z^2         + x^3
+#define F_TAIL_96                                                              \
+  { 2, 2, 0, 2, 0 } // f(z) =  z^96         +   x*z^3         + x*z   + x
+#define F_TAIL_128                                                             \
+  { 4, 8, 0, 4, 2 } // f(z) = z^128 + x*z^4 + x^2*z^3         + x^3*z + x^2
+
+#define MAYO_1_n 66
+#define MAYO_1_m 64
+#define MAYO_1_o 8
+#define MAYO_1_v (MAYO_1_n - MAYO_1_o)
+#define MAYO_1_A_cols (MAYO_1_k * MAYO_1_o + 1)
+#define MAYO_1_k 9
+#define MAYO_1_q 16
+#define MAYO_1_m_bytes 32
+#define MAYO_1_O_bytes 232
+#define MAYO_1_v_bytes 29
+#define MAYO_1_r_bytes 36
+#define MAYO_1_P1_bytes 54752
+#define MAYO_1_P2_bytes 14848
+#define MAYO_1_P3_bytes 1152
+#define MAYO_1_csk_bytes 24
+#define MAYO_1_esk_bytes 69856
+#define MAYO_1_cpk_bytes 1168
+#define MAYO_1_epk_bytes 70752
+#define MAYO_1_sig_bytes 321
+#define MAYO_1_f_tail F_TAIL_64
+#define MAYO_1_f_tail_arr f_tail_64
+#define MAYO_1_salt_bytes 24
+#define MAYO_1_digest_bytes 32
+#define MAYO_1_pk_seed_bytes 16
+#define MAYO_1_sk_seed_bytes 24
+
+#define MAYO_2_n 78
+#define MAYO_2_m 64
+#define MAYO_2_o 18
+#define MAYO_2_v (MAYO_2_n - MAYO_2_o)
+#define MAYO_2_A_cols (MAYO_2_k * MAYO_2_o + 1)
+#define MAYO_2_k 4
+#define MAYO_2_q 16
+#define MAYO_2_m_bytes 32
+#define MAYO_2_O_bytes 540
+#define MAYO_2_v_bytes 30
+#define MAYO_2_r_bytes 36
+#define MAYO_2_P1_bytes 58560
+#define MAYO_2_P2_bytes 34560
+#define MAYO_2_P3_bytes 5472
+#define MAYO_2_csk_bytes 24
+#define MAYO_2_esk_bytes 93684
+#define MAYO_2_cpk_bytes 5488
+#define MAYO_2_epk_bytes 98592
+#define MAYO_2_sig_bytes 180
+#define MAYO_2_f_tail F_TAIL_64
+#define MAYO_2_f_tail_arr f_tail_64
+#define MAYO_2_salt_bytes 24
+#define MAYO_2_digest_bytes 32
+#define MAYO_2_pk_seed_bytes 16
+#define MAYO_2_sk_seed_bytes 24
+
+#define MAYO_3_n 99
+#define MAYO_3_m 96
+#define MAYO_3_o 10
+#define MAYO_3_v (MAYO_3_n - MAYO_3_o)
+#define MAYO_3_A_cols (MAYO_3_k * MAYO_3_o + 1)
+#define MAYO_3_k 11
+#define MAYO_3_q 16
+#define MAYO_3_m_bytes 48
+#define MAYO_3_O_bytes 445
+#define MAYO_3_v_bytes 45
+#define MAYO_3_r_bytes 55
+#define MAYO_3_P1_bytes 192240
+#define MAYO_3_P2_bytes 42720
+#define MAYO_3_P3_bytes 2640
+#define MAYO_3_csk_bytes 32
+#define MAYO_3_esk_bytes 235437
+#define MAYO_3_cpk_bytes 2656
+#define MAYO_3_epk_bytes 237600
+#define MAYO_3_sig_bytes 577
+#define MAYO_3_f_tail F_TAIL_96
+#define MAYO_3_f_tail_arr f_tail_96
+#define MAYO_3_salt_bytes 32
+#define MAYO_3_digest_bytes 48
+#define MAYO_3_pk_seed_bytes 16
+#define MAYO_3_sk_seed_bytes 32
+
+#define MAYO_5_n 133
+#define MAYO_5_m 128
+#define MAYO_5_o 12
+#define MAYO_5_v (MAYO_5_n - MAYO_5_o)
+#define MAYO_5_A_cols (MAYO_5_k * MAYO_5_o + 1)
+#define MAYO_5_k 12
+#define MAYO_5_q 16
+#define MAYO_5_m_bytes 64
+#define MAYO_5_O_bytes 726
+#define MAYO_5_v_bytes 61
+#define MAYO_5_r_bytes 72
+#define MAYO_5_P1_bytes 472384
+#define MAYO_5_P2_bytes 92928
+#define MAYO_5_P3_bytes 4992
+#define MAYO_5_csk_bytes 40
+#define MAYO_5_esk_bytes 566078
+#define MAYO_5_cpk_bytes 5008
+#define MAYO_5_epk_bytes 570304
+#define MAYO_5_sig_bytes 838
+#define MAYO_5_f_tail F_TAIL_128
+#define MAYO_5_f_tail_arr f_tail_128
+#define MAYO_5_salt_bytes 40
+#define MAYO_5_digest_bytes 64
+#define MAYO_5_pk_seed_bytes 16
+#define MAYO_5_sk_seed_bytes 40
+
+#define PARAM_JOIN2_(a, b) a##_##b
+#define PARAM_JOIN2(a, b) PARAM_JOIN2_(a, b)
+#define PARAM_NAME(end) PARAM_JOIN2(MAYO_VARIANT, end)
+
+#ifdef ENABLE_PARAMS_DYNAMIC
+#define NAME_MAX mayo5
+#define N_MAX 133
+#define M_MAX 128
+#define O_MAX 18
+#define K_MAX 12
+#define Q_MAX 16
+#define PK_SEED_BYTES_MAX 16
+#define SK_SEED_BYTES_MAX 40
+#define SALT_BYTES_MAX 40
+#define DIGEST_BYTES_MAX 64
+#define O_BYTES_MAX 726
+#define V_BYTES_MAX 61
+#define R_BYTES_MAX 72
+#define P1_BYTES_MAX 472384
+#define P2_BYTES_MAX 92928
+#define P3_BYTES_MAX 5472
+#define SIG_BYTES_MAX 838
+#define CPK_BYTES_MAX 5488
+#define CSK_BYTES_MAX 40
+#define ESK_BYTES_MAX 566078
+#define EPK_BYTES_MAX 570304
+#define N_MINUS_O_MAX 121
+#define M_BYTES_MAX 64
+#elif defined(MAYO_VARIANT)
+#define M_MAX PARAM_NAME(m)
+#define N_MAX PARAM_NAME(n)
+#define O_MAX PARAM_NAME(o)
+#define V_MAX PARAM_NAME(v)
+#define K_MAX PARAM_NAME(k)
+#define Q_MAX PARAM_NAME(q)
+#define M_BYTES_MAX PARAM_NAME(m_bytes)
+#define O_BYTES_MAX PARAM_NAME(O_bytes)
+#define V_BYTES_MAX PARAM_NAME(v_bytes)
+#define R_BYTES_MAX PARAM_NAME(r_bytes)
+#define P1_BYTES_MAX PARAM_NAME(P1_bytes)
+#define P2_BYTES_MAX PARAM_NAME(P2_bytes)
+#define P3_BYTES_MAX PARAM_NAME(P3_bytes)
+#define CSK_BYTES_MAX PARAM_NAME(csk_bytes)
+#define ESK_BYTES_MAX PARAM_NAME(esk_bytes)
+#define CPK_BYTES_MAX PARAM_NAME(cpk_bytes)
+#define EPK_BYTES_MAX PARAM_NAME(epk_bytes)
+#define N_MINUS_O_MAX (N_MAX - O_MAX)
+#define SALT_BYTES_MAX PARAM_NAME(salt_bytes)
+#define DIGEST_BYTES_MAX PARAM_NAME(digest_bytes)
+#define PK_SEED_BYTES_MAX PARAM_NAME(pk_seed_bytes)
+#define SK_SEED_BYTES_MAX SALT_BYTES_MAX
+#else
+#error "Parameter not specified"
+#endif
+
+/**
+ * Struct defining MAYO parameters
+ */
+typedef struct {
+    int m;
+    int n;
+    int o;
+    int k;
+    int q;
+    const unsigned char *f_tail;
+    int m_bytes;
+    int O_bytes;
+    int v_bytes;
+    int r_bytes;
+    int R_bytes;
+    int P1_bytes;
+    int P2_bytes;
+    int P3_bytes;
+    int csk_bytes;
+    int esk_bytes;
+    int cpk_bytes;
+    int epk_bytes;
+    int sig_bytes;
+    int salt_bytes;
+    int sk_seed_bytes;
+    int digest_bytes;
+    int pk_seed_bytes;
+    const char *name;
+} mayo_params_t;
+
+typedef struct sk_t {
+    uint8_t o[O_BYTES_MAX];
+    uint32_t p[P1_BYTES_MAX/4 + P2_BYTES_MAX/4];
+} sk_t;
+
+/**
+ * MAYO parameter sets
+ */
+extern const mayo_params_t MAYO_1;
+extern const mayo_params_t MAYO_2;
+extern const mayo_params_t MAYO_3;
+extern const mayo_params_t MAYO_5;
+
+/**
+ * Status codes
+ */
+#define MAYO_OK 0
+#define MAYO_ERR 1
+
+/**
+ * Mayo keypair generation.
+ *
+ * The implementation corresponds to Mayo.CompactKeyGen() in the Mayo spec.
+ * The caller is responsible to allocate sufficient memory to hold pk and sk.
+ *
+ * @param[in] p Mayo parameter set
+ * @param[out] pk Mayo public key
+ * @param[out] sk Mayo secret key
+ * @return int status code
+ */
+int mayo_keypair(const mayo_params_t *p, unsigned char *pk, unsigned char *sk);
+
+/**
+ * MAYO signature generation.
+ *
+ * The implementation performs Mayo.expandSK() + Mayo.sign() in the Mayo spec.
+ * Keys provided is a compacted secret keys.
+ * The caller is responsible to allocate sufficient memory to hold sm.
+ *
+ * @param[in] p Mayo parameter set
+ * @param[out] sm Signature concatenated with message
+ * @param[out] smlen Pointer to the length of sm
+ * @param[in] m Message to be signed
+ * @param[in] mlen Message length
+ * @param[in] sk Compacted secret key
+ * @return int status code
+ */
+int mayo_sign(const mayo_params_t *p, unsigned char *sm,
+              unsigned long long *smlen, const unsigned char *m,
+              unsigned long long mlen, const unsigned char *sk);
+
+/**
+ * Mayo open signature.
+ *
+ * The implementation performs Mayo.verify(). If the signature verification succeeded, the original message is stored in m.
+ * Keys provided is a compact public key.
+ * The caller is responsible to allocate sufficient memory to hold m.
+ *
+ * @param[in] p Mayo parameter set
+ * @param[out] m Message stored if verification succeeds
+ * @param[out] mlen Pointer to the length of m
+ * @param[in] sm Signature concatenated with message
+ * @param[in] smlen Length of sm
+ * @param[in] pk Compacted public key
+ * @return int status code
+ */
+int mayo_open(const mayo_params_t *p, unsigned char *m,
+              unsigned long long *mlen, const unsigned char *sm,
+              unsigned long long smlen, const unsigned char *pk);
+
+/**
+ * Mayo compact keypair generation.
+ *
+ * The implementation corresponds to Mayo.CompactKeyGen() in the Mayo spec.
+ * The caller is responsible to allocate sufficient memory to hold pk and sk.
+ * 
+ * outputs a pair (csk, cpk) \in B^{csk_bytes} x B^{cpk_bytes}, where csk and
+ * cpk are compact representations of a Mayo secret key and public key
+ *
+ * @param[in] p Mayo parameter set
+ * @param[out] cpk Mayo compacted public key
+ * @param[out] csk Mayo compacted secret key
+ * @return int status code
+ */
+int mayo_keypair_compact(const mayo_params_t *p, unsigned char *cpk,
+                         unsigned char *csk);
+
+/**
+ * Mayo expand public key.
+ *
+ * The implementation corresponds to Mayo.expandPK() in the Mayo spec.
+ * The caller is responsible to allocate sufficient memory to hold epk.
+ *
+ * @param[in] p Mayo parameter set
+ * @param[in] cpk Compacted public key.
+ * @param[out] epk Expanded public key.
+ * @return int return code
+ */
+int mayo_expand_pk(const mayo_params_t *p, const unsigned char *cpk,
+                   unsigned char *epk);
+
+/**
+ * Mayo expand secret key.
+ *
+ * The implementation corresponds to Mayo.expandSK() in the Mayo spec.
+ * The caller is responsible to allocate sufficient memory to hold esk.
+ *
+ * @param[in] p Mayo parameter set
+ * @param[in] csk Compacted secret key.
+ * @param[out] esk Expanded secret key.
+ * @return int return code
+ */
+int mayo_expand_sk(const mayo_params_t *p, const unsigned char *csk,
+                   sk_t *esk);
+
+/**
+ * Mayo verify signature.
+ *
+ * The implementation performs Mayo.verify(). If the signature verification succeeded, returns 0, otherwise 1.
+ * Keys provided is a compact public key.
+ *
+ * @param[in] p Mayo parameter set
+ * @param[out] m Message stored if verification succeeds
+ * @param[out] mlen Pointer to the length of m
+ * @param[in] sig Signature
+ * @param[in] siglen Length of sig
+ * @param[in] pk Compacted public key
+ * @return int 0 if verification succeeded, 1 otherwise.
+ */
+int mayo_verify(const mayo_params_t *p, const unsigned char *m,
+                unsigned long long mlen, const unsigned char *sig,
+                  const unsigned char *pk);
+
+#endif

--- a/crypto_sign/mayo1/ref/mem.c
+++ b/crypto_sign/mayo1/ref/mem.c
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <string.h>
+#include <stdlib.h>
+
+void mayo_secure_free(void *mem, size_t size) {
+    if (mem) {
+        typedef void *(*memset_t)(void *, int, size_t);
+        static volatile memset_t memset_func = memset;
+        memset_func(mem, 0, size);
+        free(mem);
+    }
+}
+void mayo_secure_clear(void *mem, size_t size) {
+    typedef void *(*memset_t)(void *, int, size_t);
+    static volatile memset_t memset_func = memset;
+    memset_func(mem, 0, size);
+}

--- a/crypto_sign/mayo1/ref/mem.h
+++ b/crypto_sign/mayo1/ref/mem.h
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef MEM_H
+#define MEM_H
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(__GNUC__) || defined(__clang__)
+#define BSWAP32(i) __builtin_bswap32((i))
+#else
+#define BSWAP32(i) ((((i) >> 24) & 0xff) | (((i) >> 8) & 0xff00) | (((i) & 0xff00) << 8) | ((i) << 24))
+#endif
+
+// a > b -> b - a is negative
+// returns 0xFFFFFFFF if true, 0x00000000 if false
+static inline uint32_t ct_is_greater_than(int a, int b) {
+    int32_t diff = b - a;
+    return (uint32_t) (diff >> (8*sizeof(uint32_t)-1));
+}
+
+// if a == b -> 0x00000000, else 0xFFFFFFFF
+static inline uint32_t ct_compare_32(int a, int b) {
+    return (uint32_t)((-(int32_t)(a ^ b)) >> (8*sizeof(uint32_t)-1));
+}
+
+// if a == b -> 0x00, else 0xFF
+static inline unsigned char ct_compare_8(unsigned char a, unsigned char b) {
+    return (int8_t)((-(int32_t)(a ^ b)) >> (8*sizeof(uint32_t)-1));
+}
+
+/**
+ * Clears and frees allocated memory.
+ * 
+ * @param[out] mem Memory to be cleared and freed.
+ * @param size Size of memory to be cleared and freed.
+ */
+void mayo_secure_free(void *mem, size_t size);
+
+/**
+ * Clears memory.
+ * 
+ * @param[out] mem Memory to be cleared.
+ * @param size Size of memory to be cleared.
+ */
+void mayo_secure_clear(void *mem, size_t size);
+
+#endif

--- a/crypto_sign/mayo1/ref/params.c
+++ b/crypto_sign/mayo1/ref/params.c
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <mayo.h>
+
+static const unsigned char f_tail_64[] = F_TAIL_64;
+static const unsigned char f_tail_96[] = F_TAIL_96;
+static const unsigned char f_tail_128[] = F_TAIL_128;
+
+#define MAYO_GEN_PARAMS(nm) \
+  const mayo_params_t nm = { \
+    .m = PARAM_JOIN2(nm, m), \
+    .n = PARAM_JOIN2(nm, n), \
+    .o = PARAM_JOIN2(nm, o), \
+    .k = PARAM_JOIN2(nm, k), \
+    .q = PARAM_JOIN2(nm, q), \
+    .f_tail = PARAM_JOIN2(nm, f_tail_arr), \
+    .m_bytes = PARAM_JOIN2(nm, m_bytes), \
+    .O_bytes = PARAM_JOIN2(nm, O_bytes), \
+    .v_bytes = PARAM_JOIN2(nm, v_bytes), \
+    .r_bytes = PARAM_JOIN2(nm, r_bytes), \
+    .P1_bytes = PARAM_JOIN2(nm, P1_bytes), \
+    .P2_bytes = PARAM_JOIN2(nm, P2_bytes), \
+    .P3_bytes = PARAM_JOIN2(nm, P3_bytes), \
+    .csk_bytes = PARAM_JOIN2(nm, csk_bytes), \
+    .esk_bytes = PARAM_JOIN2(nm, esk_bytes), \
+    .cpk_bytes = PARAM_JOIN2(nm, cpk_bytes), \
+    .epk_bytes = PARAM_JOIN2(nm, epk_bytes), \
+    .sig_bytes = PARAM_JOIN2(nm, sig_bytes), \
+    .salt_bytes = PARAM_JOIN2(nm, salt_bytes), \
+    .sk_seed_bytes = PARAM_JOIN2(nm, sk_seed_bytes), \
+    .digest_bytes = PARAM_JOIN2(nm, digest_bytes), \
+    .pk_seed_bytes = PARAM_JOIN2(nm, pk_seed_bytes), \
+    .name = #nm \
+  };
+
+MAYO_GEN_PARAMS(MAYO_1);
+MAYO_GEN_PARAMS(MAYO_2);
+MAYO_GEN_PARAMS(MAYO_3);
+MAYO_GEN_PARAMS(MAYO_5);

--- a/crypto_sign/mayo1/ref/rng.h
+++ b/crypto_sign/mayo1/ref/rng.h
@@ -1,0 +1,1 @@
+#include "randombytes.h"

--- a/crypto_sign/mayo1/ref/simple_arithmetic.h
+++ b/crypto_sign/mayo1/ref/simple_arithmetic.h
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SIMPLE_ARITHMETIC_H
+#define SIMPLE_ARITHMETIC_H
+
+// GF(16) multiplication mod x^4 + x + 1
+static inline unsigned char mul_f(unsigned char a, unsigned char b) {
+    // carryless multiply
+    unsigned char p;
+    p  = (a & 1)*b;
+    p ^= (a & 2)*b;
+    p ^= (a & 4)*b;
+    p ^= (a & 8)*b;
+
+    // reduce mod x^4 + x + 1
+    unsigned char top_p = p & 0xf0;
+    unsigned char out = (p ^ (top_p >> 4) ^ (top_p >> 3)) & 0x0f;
+    return out;
+}
+
+static inline uint64_t mul_fx8(unsigned char a, uint64_t b) {
+    // carryless multiply
+    uint64_t p;
+    p  = (a & 1)*b;
+    p ^= (a & 2)*b;
+    p ^= (a & 4)*b;
+    p ^= (a & 8)*b;
+
+    // reduce mod x^4 + x + 1
+    uint64_t top_p = p & 0xf0f0f0f0f0f0f0f0;
+    uint64_t out = (p ^ (top_p >> 4) ^ (top_p >> 3)) & 0x0f0f0f0f0f0f0f0f;
+    return out;
+}
+
+// GF(16) addition
+static inline unsigned char add_f(unsigned char a, unsigned char b) {
+    return a ^ b;
+}
+
+// GF(16) subtraction
+static inline unsigned char sub_f(unsigned char a, unsigned char b) {
+    return a ^ b;
+}
+
+// GF(16) negation
+static inline unsigned char neg_f(unsigned char a) {
+    return a;
+}
+
+static inline unsigned char inverse_f(unsigned char a) {
+    // static unsigned char table[16] = {0, 1, 9, 14, 13, 11, 7, 6, 15, 2, 12, 5,
+    // 10, 4, 3, 8}; return table[a & 15];
+
+    unsigned char a2 = mul_f(a, a);
+    unsigned char a4 = mul_f(a2, a2);
+    unsigned char a8 = mul_f(a4, a4);
+    unsigned char a6 = mul_f(a2, a4);
+    unsigned char a14 = mul_f(a8, a6);
+
+    return a14;
+}
+
+static inline unsigned char lincomb(const unsigned char *a,
+                                    const unsigned char *b, int n, int m) {
+    unsigned char ret = 0;
+    for (int i = 0; i < n; ++i, b += m) {
+        ret = add_f(mul_f(a[i], *b), ret);
+    }
+    return ret;
+}
+
+static inline unsigned char lincomb_transpose_a(const unsigned char *a,
+        const unsigned char *b, int n,
+        int m, int o) {
+    unsigned char ret = 0;
+    for (int i = 0; i < n; ++i, a += m, b += o) {
+        ret = add_f(mul_f(*a, *b), ret);
+    }
+    return ret;
+}
+
+static inline unsigned char lincomb_transpose_b(const unsigned char *a,
+        const unsigned char *b, int n) {
+    unsigned char ret = 0;
+    for (int i = 0; i < n; ++i) {
+        ret = add_f(mul_f(a[i], b[i]), ret);
+    }
+    return ret;
+}
+
+static inline void mat_mul(const unsigned char *a, const unsigned char *b,
+                    unsigned char *c, int colrow_ab, int row_a, int col_b) {
+    for (int i = 0; i < row_a; ++i, a += colrow_ab) {
+        for (int j = 0; j < col_b; ++j, ++c) {
+            *c = lincomb(a, b + j, colrow_ab, col_b);
+        }
+    }
+}
+
+static inline void mat_add(const unsigned char *a, const unsigned char *b,
+                    unsigned char *c, int m, int n) {
+    for (int i = 0; i < m; ++i) {
+        for (int j = 0; j < n; ++j) {
+            *(c + i * n + j) = add_f(*(a + i * n + j), *(b + i * n + j));
+        }
+    }
+}
+
+#endif

--- a/crypto_sign/mayo2/ref/LICENSE
+++ b/crypto_sign/mayo2/ref/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crypto_sign/mayo2/ref/aes_ctr.c
+++ b/crypto_sign/mayo2/ref/aes_ctr.c
@@ -1,0 +1,1 @@
+../../mayo1/ref/aes_ctr.c

--- a/crypto_sign/mayo2/ref/aes_ctr.h
+++ b/crypto_sign/mayo2/ref/aes_ctr.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/aes_ctr.h

--- a/crypto_sign/mayo2/ref/api.c
+++ b/crypto_sign/mayo2/ref/api.c
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <api.h>
+#include <mayo.h>
+
+int
+crypto_sign_keypair(unsigned char *pk, unsigned char *sk) {
+    return mayo_keypair(&MAYO_2, pk, sk);
+}
+
+#ifndef PQM4
+int
+crypto_sign(unsigned char *sm, unsigned long long *smlen,
+            const unsigned char *m, unsigned long long mlen,
+            const unsigned char *sk) {
+    return mayo_sign(&MAYO_2, sm, smlen, m, mlen, sk);
+}
+
+int
+crypto_sign_open(unsigned char *m, unsigned long long *mlen,
+                 const unsigned char *sm, unsigned long long smlen,
+                 const unsigned char *pk) {
+    return mayo_open(&MAYO_2, m, mlen, sm, smlen, pk);
+}
+
+
+#else
+int
+crypto_sign(unsigned char *sm, size_t *smlen,
+            const unsigned char *m, size_t mlen,
+            const unsigned char *sk) {
+
+    unsigned long long smlen_ll;
+    int rc = mayo_sign(&MAYO_2, sm, &smlen_ll, m, mlen, sk);
+    *smlen = smlen_ll;
+    return rc;
+}
+
+int
+crypto_sign_open(unsigned char *m, size_t *mlen,
+                 const unsigned char *sm, size_t smlen,
+                 const unsigned char *pk) {
+    unsigned long long mlen_ll;
+    int rc = mayo_open(&MAYO_2, m, &mlen_ll, sm, smlen, pk);
+    *mlen = mlen_ll;
+    return rc;
+}
+#endif

--- a/crypto_sign/mayo2/ref/api.h
+++ b/crypto_sign/mayo2/ref/api.h
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef api_h
+#define api_h
+
+#define CRYPTO_SECRETKEYBYTES 24
+#define CRYPTO_PUBLICKEYBYTES 5488
+#define CRYPTO_BYTES 180
+
+#define CRYPTO_ALGNAME "MAYO_2"
+#ifndef PQM4
+#define PQM4
+#endif
+
+int
+crypto_sign_keypair(unsigned char *pk, unsigned char *sk);
+
+#ifndef PQM4
+int
+crypto_sign(unsigned char *sm, unsigned long long *smlen,
+            const unsigned char *m, unsigned long long mlen,
+            const unsigned char *sk);
+
+int
+crypto_sign_open(unsigned char *m, unsigned long long *mlen,
+                 const unsigned char *sm, unsigned long long smlen,
+                 const unsigned char *pk);
+
+#else
+#include <stddef.h>
+
+int
+crypto_sign(unsigned char *sm, size_t *smlen,
+            const unsigned char *m, size_t mlen,
+            const unsigned char *sk);
+
+int
+crypto_sign_open(unsigned char *m, size_t *mlen,
+                 const unsigned char *sm, size_t smlen,
+                 const unsigned char *pk);
+#endif
+
+#endif /* api_h */

--- a/crypto_sign/mayo2/ref/bitsliced_arithmetic.c
+++ b/crypto_sign/mayo2/ref/bitsliced_arithmetic.c
@@ -1,0 +1,1 @@
+../../mayo1/ref/bitsliced_arithmetic.c

--- a/crypto_sign/mayo2/ref/bitsliced_arithmetic.h
+++ b/crypto_sign/mayo2/ref/bitsliced_arithmetic.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/bitsliced_arithmetic.h

--- a/crypto_sign/mayo2/ref/bitsliced_arithmetic_128.h
+++ b/crypto_sign/mayo2/ref/bitsliced_arithmetic_128.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/bitsliced_arithmetic_128.h

--- a/crypto_sign/mayo2/ref/bitsliced_arithmetic_64.h
+++ b/crypto_sign/mayo2/ref/bitsliced_arithmetic_64.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/bitsliced_arithmetic_64.h

--- a/crypto_sign/mayo2/ref/bitsliced_arithmetic_96.h
+++ b/crypto_sign/mayo2/ref/bitsliced_arithmetic_96.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/bitsliced_arithmetic_96.h

--- a/crypto_sign/mayo2/ref/debug_bench_tools.h
+++ b/crypto_sign/mayo2/ref/debug_bench_tools.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/debug_bench_tools.h

--- a/crypto_sign/mayo2/ref/echelon_form.h
+++ b/crypto_sign/mayo2/ref/echelon_form.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/echelon_form.h

--- a/crypto_sign/mayo2/ref/mayo.c
+++ b/crypto_sign/mayo2/ref/mayo.c
@@ -1,0 +1,1 @@
+../../mayo1/ref/mayo.c

--- a/crypto_sign/mayo2/ref/mayo.h
+++ b/crypto_sign/mayo2/ref/mayo.h
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef MAYO_H
+#define MAYO_H
+
+#define MAYO_VARIANT MAYO_2
+#ifndef PQM4
+#define PQM4
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define F_TAIL_LEN 5
+#define F_TAIL_64                                                              \
+  { 8, 0, 2, 8, 0 } // f(z) =  z^64         + x^3*z^3 + x*z^2         + x^3
+#define F_TAIL_96                                                              \
+  { 2, 2, 0, 2, 0 } // f(z) =  z^96         +   x*z^3         + x*z   + x
+#define F_TAIL_128                                                             \
+  { 4, 8, 0, 4, 2 } // f(z) = z^128 + x*z^4 + x^2*z^3         + x^3*z + x^2
+
+#define MAYO_1_n 66
+#define MAYO_1_m 64
+#define MAYO_1_o 8
+#define MAYO_1_v (MAYO_1_n - MAYO_1_o)
+#define MAYO_1_A_cols (MAYO_1_k * MAYO_1_o + 1)
+#define MAYO_1_k 9
+#define MAYO_1_q 16
+#define MAYO_1_m_bytes 32
+#define MAYO_1_O_bytes 232
+#define MAYO_1_v_bytes 29
+#define MAYO_1_r_bytes 36
+#define MAYO_1_P1_bytes 54752
+#define MAYO_1_P2_bytes 14848
+#define MAYO_1_P3_bytes 1152
+#define MAYO_1_csk_bytes 24
+#define MAYO_1_esk_bytes 69856
+#define MAYO_1_cpk_bytes 1168
+#define MAYO_1_epk_bytes 70752
+#define MAYO_1_sig_bytes 321
+#define MAYO_1_f_tail F_TAIL_64
+#define MAYO_1_f_tail_arr f_tail_64
+#define MAYO_1_salt_bytes 24
+#define MAYO_1_digest_bytes 32
+#define MAYO_1_pk_seed_bytes 16
+#define MAYO_1_sk_seed_bytes 24
+
+#define MAYO_2_n 78
+#define MAYO_2_m 64
+#define MAYO_2_o 18
+#define MAYO_2_v (MAYO_2_n - MAYO_2_o)
+#define MAYO_2_A_cols (MAYO_2_k * MAYO_2_o + 1)
+#define MAYO_2_k 4
+#define MAYO_2_q 16
+#define MAYO_2_m_bytes 32
+#define MAYO_2_O_bytes 540
+#define MAYO_2_v_bytes 30
+#define MAYO_2_r_bytes 36
+#define MAYO_2_P1_bytes 58560
+#define MAYO_2_P2_bytes 34560
+#define MAYO_2_P3_bytes 5472
+#define MAYO_2_csk_bytes 24
+#define MAYO_2_esk_bytes 93684
+#define MAYO_2_cpk_bytes 5488
+#define MAYO_2_epk_bytes 98592
+#define MAYO_2_sig_bytes 180
+#define MAYO_2_f_tail F_TAIL_64
+#define MAYO_2_f_tail_arr f_tail_64
+#define MAYO_2_salt_bytes 24
+#define MAYO_2_digest_bytes 32
+#define MAYO_2_pk_seed_bytes 16
+#define MAYO_2_sk_seed_bytes 24
+
+#define MAYO_3_n 99
+#define MAYO_3_m 96
+#define MAYO_3_o 10
+#define MAYO_3_v (MAYO_3_n - MAYO_3_o)
+#define MAYO_3_A_cols (MAYO_3_k * MAYO_3_o + 1)
+#define MAYO_3_k 11
+#define MAYO_3_q 16
+#define MAYO_3_m_bytes 48
+#define MAYO_3_O_bytes 445
+#define MAYO_3_v_bytes 45
+#define MAYO_3_r_bytes 55
+#define MAYO_3_P1_bytes 192240
+#define MAYO_3_P2_bytes 42720
+#define MAYO_3_P3_bytes 2640
+#define MAYO_3_csk_bytes 32
+#define MAYO_3_esk_bytes 235437
+#define MAYO_3_cpk_bytes 2656
+#define MAYO_3_epk_bytes 237600
+#define MAYO_3_sig_bytes 577
+#define MAYO_3_f_tail F_TAIL_96
+#define MAYO_3_f_tail_arr f_tail_96
+#define MAYO_3_salt_bytes 32
+#define MAYO_3_digest_bytes 48
+#define MAYO_3_pk_seed_bytes 16
+#define MAYO_3_sk_seed_bytes 32
+
+#define MAYO_5_n 133
+#define MAYO_5_m 128
+#define MAYO_5_o 12
+#define MAYO_5_v (MAYO_5_n - MAYO_5_o)
+#define MAYO_5_A_cols (MAYO_5_k * MAYO_5_o + 1)
+#define MAYO_5_k 12
+#define MAYO_5_q 16
+#define MAYO_5_m_bytes 64
+#define MAYO_5_O_bytes 726
+#define MAYO_5_v_bytes 61
+#define MAYO_5_r_bytes 72
+#define MAYO_5_P1_bytes 472384
+#define MAYO_5_P2_bytes 92928
+#define MAYO_5_P3_bytes 4992
+#define MAYO_5_csk_bytes 40
+#define MAYO_5_esk_bytes 566078
+#define MAYO_5_cpk_bytes 5008
+#define MAYO_5_epk_bytes 570304
+#define MAYO_5_sig_bytes 838
+#define MAYO_5_f_tail F_TAIL_128
+#define MAYO_5_f_tail_arr f_tail_128
+#define MAYO_5_salt_bytes 40
+#define MAYO_5_digest_bytes 64
+#define MAYO_5_pk_seed_bytes 16
+#define MAYO_5_sk_seed_bytes 40
+
+#define PARAM_JOIN2_(a, b) a##_##b
+#define PARAM_JOIN2(a, b) PARAM_JOIN2_(a, b)
+#define PARAM_NAME(end) PARAM_JOIN2(MAYO_VARIANT, end)
+
+#ifdef ENABLE_PARAMS_DYNAMIC
+#define NAME_MAX mayo5
+#define N_MAX 133
+#define M_MAX 128
+#define O_MAX 18
+#define K_MAX 12
+#define Q_MAX 16
+#define PK_SEED_BYTES_MAX 16
+#define SK_SEED_BYTES_MAX 40
+#define SALT_BYTES_MAX 40
+#define DIGEST_BYTES_MAX 64
+#define O_BYTES_MAX 726
+#define V_BYTES_MAX 61
+#define R_BYTES_MAX 72
+#define P1_BYTES_MAX 472384
+#define P2_BYTES_MAX 92928
+#define P3_BYTES_MAX 5472
+#define SIG_BYTES_MAX 838
+#define CPK_BYTES_MAX 5488
+#define CSK_BYTES_MAX 40
+#define ESK_BYTES_MAX 566078
+#define EPK_BYTES_MAX 570304
+#define N_MINUS_O_MAX 121
+#define M_BYTES_MAX 64
+#elif defined(MAYO_VARIANT)
+#define M_MAX PARAM_NAME(m)
+#define N_MAX PARAM_NAME(n)
+#define O_MAX PARAM_NAME(o)
+#define V_MAX PARAM_NAME(v)
+#define K_MAX PARAM_NAME(k)
+#define Q_MAX PARAM_NAME(q)
+#define M_BYTES_MAX PARAM_NAME(m_bytes)
+#define O_BYTES_MAX PARAM_NAME(O_bytes)
+#define V_BYTES_MAX PARAM_NAME(v_bytes)
+#define R_BYTES_MAX PARAM_NAME(r_bytes)
+#define P1_BYTES_MAX PARAM_NAME(P1_bytes)
+#define P2_BYTES_MAX PARAM_NAME(P2_bytes)
+#define P3_BYTES_MAX PARAM_NAME(P3_bytes)
+#define CSK_BYTES_MAX PARAM_NAME(csk_bytes)
+#define ESK_BYTES_MAX PARAM_NAME(esk_bytes)
+#define CPK_BYTES_MAX PARAM_NAME(cpk_bytes)
+#define EPK_BYTES_MAX PARAM_NAME(epk_bytes)
+#define N_MINUS_O_MAX (N_MAX - O_MAX)
+#define SALT_BYTES_MAX PARAM_NAME(salt_bytes)
+#define DIGEST_BYTES_MAX PARAM_NAME(digest_bytes)
+#define PK_SEED_BYTES_MAX PARAM_NAME(pk_seed_bytes)
+#define SK_SEED_BYTES_MAX SALT_BYTES_MAX
+#else
+#error "Parameter not specified"
+#endif
+
+/**
+ * Struct defining MAYO parameters
+ */
+typedef struct {
+    int m;
+    int n;
+    int o;
+    int k;
+    int q;
+    const unsigned char *f_tail;
+    int m_bytes;
+    int O_bytes;
+    int v_bytes;
+    int r_bytes;
+    int R_bytes;
+    int P1_bytes;
+    int P2_bytes;
+    int P3_bytes;
+    int csk_bytes;
+    int esk_bytes;
+    int cpk_bytes;
+    int epk_bytes;
+    int sig_bytes;
+    int salt_bytes;
+    int sk_seed_bytes;
+    int digest_bytes;
+    int pk_seed_bytes;
+    const char *name;
+} mayo_params_t;
+
+typedef struct sk_t {
+    uint8_t o[O_BYTES_MAX];
+    uint32_t p[P1_BYTES_MAX/4 + P2_BYTES_MAX/4];
+} sk_t;
+
+/**
+ * MAYO parameter sets
+ */
+extern const mayo_params_t MAYO_1;
+extern const mayo_params_t MAYO_2;
+extern const mayo_params_t MAYO_3;
+extern const mayo_params_t MAYO_5;
+
+/**
+ * Status codes
+ */
+#define MAYO_OK 0
+#define MAYO_ERR 1
+
+/**
+ * Mayo keypair generation.
+ *
+ * The implementation corresponds to Mayo.CompactKeyGen() in the Mayo spec.
+ * The caller is responsible to allocate sufficient memory to hold pk and sk.
+ *
+ * @param[in] p Mayo parameter set
+ * @param[out] pk Mayo public key
+ * @param[out] sk Mayo secret key
+ * @return int status code
+ */
+int mayo_keypair(const mayo_params_t *p, unsigned char *pk, unsigned char *sk);
+
+/**
+ * MAYO signature generation.
+ *
+ * The implementation performs Mayo.expandSK() + Mayo.sign() in the Mayo spec.
+ * Keys provided is a compacted secret keys.
+ * The caller is responsible to allocate sufficient memory to hold sm.
+ *
+ * @param[in] p Mayo parameter set
+ * @param[out] sm Signature concatenated with message
+ * @param[out] smlen Pointer to the length of sm
+ * @param[in] m Message to be signed
+ * @param[in] mlen Message length
+ * @param[in] sk Compacted secret key
+ * @return int status code
+ */
+int mayo_sign(const mayo_params_t *p, unsigned char *sm,
+              unsigned long long *smlen, const unsigned char *m,
+              unsigned long long mlen, const unsigned char *sk);
+
+/**
+ * Mayo open signature.
+ *
+ * The implementation performs Mayo.verify(). If the signature verification succeeded, the original message is stored in m.
+ * Keys provided is a compact public key.
+ * The caller is responsible to allocate sufficient memory to hold m.
+ *
+ * @param[in] p Mayo parameter set
+ * @param[out] m Message stored if verification succeeds
+ * @param[out] mlen Pointer to the length of m
+ * @param[in] sm Signature concatenated with message
+ * @param[in] smlen Length of sm
+ * @param[in] pk Compacted public key
+ * @return int status code
+ */
+int mayo_open(const mayo_params_t *p, unsigned char *m,
+              unsigned long long *mlen, const unsigned char *sm,
+              unsigned long long smlen, const unsigned char *pk);
+
+/**
+ * Mayo compact keypair generation.
+ *
+ * The implementation corresponds to Mayo.CompactKeyGen() in the Mayo spec.
+ * The caller is responsible to allocate sufficient memory to hold pk and sk.
+ * 
+ * outputs a pair (csk, cpk) \in B^{csk_bytes} x B^{cpk_bytes}, where csk and
+ * cpk are compact representations of a Mayo secret key and public key
+ *
+ * @param[in] p Mayo parameter set
+ * @param[out] cpk Mayo compacted public key
+ * @param[out] csk Mayo compacted secret key
+ * @return int status code
+ */
+int mayo_keypair_compact(const mayo_params_t *p, unsigned char *cpk,
+                         unsigned char *csk);
+
+/**
+ * Mayo expand public key.
+ *
+ * The implementation corresponds to Mayo.expandPK() in the Mayo spec.
+ * The caller is responsible to allocate sufficient memory to hold epk.
+ *
+ * @param[in] p Mayo parameter set
+ * @param[in] cpk Compacted public key.
+ * @param[out] epk Expanded public key.
+ * @return int return code
+ */
+int mayo_expand_pk(const mayo_params_t *p, const unsigned char *cpk,
+                   unsigned char *epk);
+
+/**
+ * Mayo expand secret key.
+ *
+ * The implementation corresponds to Mayo.expandSK() in the Mayo spec.
+ * The caller is responsible to allocate sufficient memory to hold esk.
+ *
+ * @param[in] p Mayo parameter set
+ * @param[in] csk Compacted secret key.
+ * @param[out] esk Expanded secret key.
+ * @return int return code
+ */
+int mayo_expand_sk(const mayo_params_t *p, const unsigned char *csk,
+                   sk_t *esk);
+
+
+/**
+ * Mayo verify signature.
+ *
+ * The implementation performs Mayo.verify(). If the signature verification succeeded, returns 0, otherwise 1.
+ * Keys provided is a compact public key.
+ *
+ * @param[in] p Mayo parameter set
+ * @param[out] m Message stored if verification succeeds
+ * @param[out] mlen Pointer to the length of m
+ * @param[in] sig Signature
+ * @param[in] siglen Length of sig
+ * @param[in] pk Compacted public key
+ * @return int 0 if verification succeeded, 1 otherwise.
+ */
+int mayo_verify(const mayo_params_t *p, const unsigned char *m,
+                unsigned long long mlen, const unsigned char *sig,
+                const unsigned char *pk);
+
+#endif

--- a/crypto_sign/mayo2/ref/mem.c
+++ b/crypto_sign/mayo2/ref/mem.c
@@ -1,0 +1,1 @@
+../../mayo1/ref/mem.c

--- a/crypto_sign/mayo2/ref/mem.h
+++ b/crypto_sign/mayo2/ref/mem.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/mem.h

--- a/crypto_sign/mayo2/ref/params.c
+++ b/crypto_sign/mayo2/ref/params.c
@@ -1,0 +1,1 @@
+../../mayo1/ref/params.c

--- a/crypto_sign/mayo2/ref/rng.h
+++ b/crypto_sign/mayo2/ref/rng.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/rng.h

--- a/crypto_sign/mayo2/ref/simple_arithmetic.h
+++ b/crypto_sign/mayo2/ref/simple_arithmetic.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/simple_arithmetic.h

--- a/crypto_sign/mayo3/ref/LICENSE
+++ b/crypto_sign/mayo3/ref/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crypto_sign/mayo3/ref/aes_ctr.c
+++ b/crypto_sign/mayo3/ref/aes_ctr.c
@@ -1,0 +1,1 @@
+../../mayo1/ref/aes_ctr.c

--- a/crypto_sign/mayo3/ref/aes_ctr.h
+++ b/crypto_sign/mayo3/ref/aes_ctr.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/aes_ctr.h

--- a/crypto_sign/mayo3/ref/api.c
+++ b/crypto_sign/mayo3/ref/api.c
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <api.h>
+#include <mayo.h>
+
+int
+crypto_sign_keypair(unsigned char *pk, unsigned char *sk) {
+    return mayo_keypair(&MAYO_3, pk, sk);
+}
+
+#ifndef PQM4
+int
+crypto_sign(unsigned char *sm, unsigned long long *smlen,
+            const unsigned char *m, unsigned long long mlen,
+            const unsigned char *sk) {
+    return mayo_sign(&MAYO_3, sm, smlen, m, mlen, sk);
+}
+
+int
+crypto_sign_open(unsigned char *m, unsigned long long *mlen,
+                 const unsigned char *sm, unsigned long long smlen,
+                 const unsigned char *pk) {
+    return mayo_open(&MAYO_3, m, mlen, sm, smlen, pk);
+}
+
+
+#else
+int
+crypto_sign(unsigned char *sm, size_t *smlen,
+            const unsigned char *m, size_t mlen,
+            const unsigned char *sk) {
+
+    unsigned long long smlen_ll;
+    int rc = mayo_sign(&MAYO_3, sm, &smlen_ll, m, mlen, sk);
+    *smlen = smlen_ll;
+    return rc;
+}
+
+int
+crypto_sign_open(unsigned char *m, size_t *mlen,
+                 const unsigned char *sm, size_t smlen,
+                 const unsigned char *pk) {
+    unsigned long long mlen_ll;
+    int rc = mayo_open(&MAYO_3, m, &mlen_ll, sm, smlen, pk);
+    *mlen = mlen_ll;
+    return rc;
+}
+#endif

--- a/crypto_sign/mayo3/ref/api.h
+++ b/crypto_sign/mayo3/ref/api.h
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef api_h
+#define api_h
+
+#define CRYPTO_SECRETKEYBYTES 32
+#define CRYPTO_PUBLICKEYBYTES 2656
+#define CRYPTO_BYTES 577
+
+#define CRYPTO_ALGNAME "MAYO_3"
+#ifndef PQM4
+#define PQM4
+#endif
+
+int
+crypto_sign_keypair(unsigned char *pk, unsigned char *sk);
+
+#ifndef PQM4
+int
+crypto_sign(unsigned char *sm, unsigned long long *smlen,
+            const unsigned char *m, unsigned long long mlen,
+            const unsigned char *sk);
+
+int
+crypto_sign_open(unsigned char *m, unsigned long long *mlen,
+                 const unsigned char *sm, unsigned long long smlen,
+                 const unsigned char *pk);
+
+#else
+#include <stddef.h>
+
+int
+crypto_sign(unsigned char *sm, size_t *smlen,
+            const unsigned char *m, size_t mlen,
+            const unsigned char *sk);
+
+int
+crypto_sign_open(unsigned char *m, size_t *mlen,
+                 const unsigned char *sm, size_t smlen,
+                 const unsigned char *pk);
+#endif
+
+#endif /* api_h */

--- a/crypto_sign/mayo3/ref/bitsliced_arithmetic.c
+++ b/crypto_sign/mayo3/ref/bitsliced_arithmetic.c
@@ -1,0 +1,1 @@
+../../mayo1/ref/bitsliced_arithmetic.c

--- a/crypto_sign/mayo3/ref/bitsliced_arithmetic.h
+++ b/crypto_sign/mayo3/ref/bitsliced_arithmetic.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/bitsliced_arithmetic.h

--- a/crypto_sign/mayo3/ref/bitsliced_arithmetic_128.h
+++ b/crypto_sign/mayo3/ref/bitsliced_arithmetic_128.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/bitsliced_arithmetic_128.h

--- a/crypto_sign/mayo3/ref/bitsliced_arithmetic_64.h
+++ b/crypto_sign/mayo3/ref/bitsliced_arithmetic_64.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/bitsliced_arithmetic_64.h

--- a/crypto_sign/mayo3/ref/bitsliced_arithmetic_96.h
+++ b/crypto_sign/mayo3/ref/bitsliced_arithmetic_96.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/bitsliced_arithmetic_96.h

--- a/crypto_sign/mayo3/ref/debug_bench_tools.h
+++ b/crypto_sign/mayo3/ref/debug_bench_tools.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/debug_bench_tools.h

--- a/crypto_sign/mayo3/ref/echelon_form.h
+++ b/crypto_sign/mayo3/ref/echelon_form.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/echelon_form.h

--- a/crypto_sign/mayo3/ref/mayo.c
+++ b/crypto_sign/mayo3/ref/mayo.c
@@ -1,0 +1,1 @@
+../../mayo1/ref/mayo.c

--- a/crypto_sign/mayo3/ref/mayo.h
+++ b/crypto_sign/mayo3/ref/mayo.h
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef MAYO_H
+#define MAYO_H
+
+#define MAYO_VARIANT MAYO_3
+#ifndef PQM4
+#define PQM4
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define F_TAIL_LEN 5
+#define F_TAIL_64                                                              \
+  { 8, 0, 2, 8, 0 } // f(z) =  z^64         + x^3*z^3 + x*z^2         + x^3
+#define F_TAIL_96                                                              \
+  { 2, 2, 0, 2, 0 } // f(z) =  z^96         +   x*z^3         + x*z   + x
+#define F_TAIL_128                                                             \
+  { 4, 8, 0, 4, 2 } // f(z) = z^128 + x*z^4 + x^2*z^3         + x^3*z + x^2
+
+#define MAYO_1_n 66
+#define MAYO_1_m 64
+#define MAYO_1_o 8
+#define MAYO_1_v (MAYO_1_n - MAYO_1_o)
+#define MAYO_1_A_cols (MAYO_1_k * MAYO_1_o + 1)
+#define MAYO_1_k 9
+#define MAYO_1_q 16
+#define MAYO_1_m_bytes 32
+#define MAYO_1_O_bytes 232
+#define MAYO_1_v_bytes 29
+#define MAYO_1_r_bytes 36
+#define MAYO_1_P1_bytes 54752
+#define MAYO_1_P2_bytes 14848
+#define MAYO_1_P3_bytes 1152
+#define MAYO_1_csk_bytes 24
+#define MAYO_1_esk_bytes 69856
+#define MAYO_1_cpk_bytes 1168
+#define MAYO_1_epk_bytes 70752
+#define MAYO_1_sig_bytes 321
+#define MAYO_1_f_tail F_TAIL_64
+#define MAYO_1_f_tail_arr f_tail_64
+#define MAYO_1_salt_bytes 24
+#define MAYO_1_digest_bytes 32
+#define MAYO_1_pk_seed_bytes 16
+#define MAYO_1_sk_seed_bytes 24
+
+#define MAYO_2_n 78
+#define MAYO_2_m 64
+#define MAYO_2_o 18
+#define MAYO_2_v (MAYO_2_n - MAYO_2_o)
+#define MAYO_2_A_cols (MAYO_2_k * MAYO_2_o + 1)
+#define MAYO_2_k 4
+#define MAYO_2_q 16
+#define MAYO_2_m_bytes 32
+#define MAYO_2_O_bytes 540
+#define MAYO_2_v_bytes 30
+#define MAYO_2_r_bytes 36
+#define MAYO_2_P1_bytes 58560
+#define MAYO_2_P2_bytes 34560
+#define MAYO_2_P3_bytes 5472
+#define MAYO_2_csk_bytes 24
+#define MAYO_2_esk_bytes 93684
+#define MAYO_2_cpk_bytes 5488
+#define MAYO_2_epk_bytes 98592
+#define MAYO_2_sig_bytes 180
+#define MAYO_2_f_tail F_TAIL_64
+#define MAYO_2_f_tail_arr f_tail_64
+#define MAYO_2_salt_bytes 24
+#define MAYO_2_digest_bytes 32
+#define MAYO_2_pk_seed_bytes 16
+#define MAYO_2_sk_seed_bytes 24
+
+#define MAYO_3_n 99
+#define MAYO_3_m 96
+#define MAYO_3_o 10
+#define MAYO_3_v (MAYO_3_n - MAYO_3_o)
+#define MAYO_3_A_cols (MAYO_3_k * MAYO_3_o + 1)
+#define MAYO_3_k 11
+#define MAYO_3_q 16
+#define MAYO_3_m_bytes 48
+#define MAYO_3_O_bytes 445
+#define MAYO_3_v_bytes 45
+#define MAYO_3_r_bytes 55
+#define MAYO_3_P1_bytes 192240
+#define MAYO_3_P2_bytes 42720
+#define MAYO_3_P3_bytes 2640
+#define MAYO_3_csk_bytes 32
+#define MAYO_3_esk_bytes 235437
+#define MAYO_3_cpk_bytes 2656
+#define MAYO_3_epk_bytes 237600
+#define MAYO_3_sig_bytes 577
+#define MAYO_3_f_tail F_TAIL_96
+#define MAYO_3_f_tail_arr f_tail_96
+#define MAYO_3_salt_bytes 32
+#define MAYO_3_digest_bytes 48
+#define MAYO_3_pk_seed_bytes 16
+#define MAYO_3_sk_seed_bytes 32
+
+#define MAYO_5_n 133
+#define MAYO_5_m 128
+#define MAYO_5_o 12
+#define MAYO_5_v (MAYO_5_n - MAYO_5_o)
+#define MAYO_5_A_cols (MAYO_5_k * MAYO_5_o + 1)
+#define MAYO_5_k 12
+#define MAYO_5_q 16
+#define MAYO_5_m_bytes 64
+#define MAYO_5_O_bytes 726
+#define MAYO_5_v_bytes 61
+#define MAYO_5_r_bytes 72
+#define MAYO_5_P1_bytes 472384
+#define MAYO_5_P2_bytes 92928
+#define MAYO_5_P3_bytes 4992
+#define MAYO_5_csk_bytes 40
+#define MAYO_5_esk_bytes 566078
+#define MAYO_5_cpk_bytes 5008
+#define MAYO_5_epk_bytes 570304
+#define MAYO_5_sig_bytes 838
+#define MAYO_5_f_tail F_TAIL_128
+#define MAYO_5_f_tail_arr f_tail_128
+#define MAYO_5_salt_bytes 40
+#define MAYO_5_digest_bytes 64
+#define MAYO_5_pk_seed_bytes 16
+#define MAYO_5_sk_seed_bytes 40
+
+#define PARAM_JOIN2_(a, b) a##_##b
+#define PARAM_JOIN2(a, b) PARAM_JOIN2_(a, b)
+#define PARAM_NAME(end) PARAM_JOIN2(MAYO_VARIANT, end)
+
+#ifdef ENABLE_PARAMS_DYNAMIC
+#define NAME_MAX mayo5
+#define N_MAX 133
+#define M_MAX 128
+#define O_MAX 18
+#define K_MAX 12
+#define Q_MAX 16
+#define PK_SEED_BYTES_MAX 16
+#define SK_SEED_BYTES_MAX 40
+#define SALT_BYTES_MAX 40
+#define DIGEST_BYTES_MAX 64
+#define O_BYTES_MAX 726
+#define V_BYTES_MAX 61
+#define R_BYTES_MAX 72
+#define P1_BYTES_MAX 472384
+#define P2_BYTES_MAX 92928
+#define P3_BYTES_MAX 5472
+#define SIG_BYTES_MAX 838
+#define CPK_BYTES_MAX 5488
+#define CSK_BYTES_MAX 40
+#define ESK_BYTES_MAX 566078
+#define EPK_BYTES_MAX 570304
+#define N_MINUS_O_MAX 121
+#define M_BYTES_MAX 64
+#elif defined(MAYO_VARIANT)
+#define M_MAX PARAM_NAME(m)
+#define N_MAX PARAM_NAME(n)
+#define O_MAX PARAM_NAME(o)
+#define V_MAX PARAM_NAME(v)
+#define K_MAX PARAM_NAME(k)
+#define Q_MAX PARAM_NAME(q)
+#define M_BYTES_MAX PARAM_NAME(m_bytes)
+#define O_BYTES_MAX PARAM_NAME(O_bytes)
+#define V_BYTES_MAX PARAM_NAME(v_bytes)
+#define R_BYTES_MAX PARAM_NAME(r_bytes)
+#define P1_BYTES_MAX PARAM_NAME(P1_bytes)
+#define P2_BYTES_MAX PARAM_NAME(P2_bytes)
+#define P3_BYTES_MAX PARAM_NAME(P3_bytes)
+#define CSK_BYTES_MAX PARAM_NAME(csk_bytes)
+#define ESK_BYTES_MAX PARAM_NAME(esk_bytes)
+#define CPK_BYTES_MAX PARAM_NAME(cpk_bytes)
+#define EPK_BYTES_MAX PARAM_NAME(epk_bytes)
+#define N_MINUS_O_MAX (N_MAX - O_MAX)
+#define SALT_BYTES_MAX PARAM_NAME(salt_bytes)
+#define DIGEST_BYTES_MAX PARAM_NAME(digest_bytes)
+#define PK_SEED_BYTES_MAX PARAM_NAME(pk_seed_bytes)
+#define SK_SEED_BYTES_MAX SALT_BYTES_MAX
+#else
+#error "Parameter not specified"
+#endif
+
+/**
+ * Struct defining MAYO parameters
+ */
+typedef struct {
+    int m;
+    int n;
+    int o;
+    int k;
+    int q;
+    const unsigned char *f_tail;
+    int m_bytes;
+    int O_bytes;
+    int v_bytes;
+    int r_bytes;
+    int R_bytes;
+    int P1_bytes;
+    int P2_bytes;
+    int P3_bytes;
+    int csk_bytes;
+    int esk_bytes;
+    int cpk_bytes;
+    int epk_bytes;
+    int sig_bytes;
+    int salt_bytes;
+    int sk_seed_bytes;
+    int digest_bytes;
+    int pk_seed_bytes;
+    const char *name;
+} mayo_params_t;
+
+typedef struct sk_t {
+    uint8_t o[O_BYTES_MAX];
+    uint32_t p[P1_BYTES_MAX/4 + P2_BYTES_MAX/4];
+} sk_t;
+
+/**
+ * MAYO parameter sets
+ */
+extern const mayo_params_t MAYO_1;
+extern const mayo_params_t MAYO_2;
+extern const mayo_params_t MAYO_3;
+extern const mayo_params_t MAYO_5;
+
+/**
+ * Status codes
+ */
+#define MAYO_OK 0
+#define MAYO_ERR 1
+
+/**
+ * Mayo keypair generation.
+ *
+ * The implementation corresponds to Mayo.CompactKeyGen() in the Mayo spec.
+ * The caller is responsible to allocate sufficient memory to hold pk and sk.
+ *
+ * @param[in] p Mayo parameter set
+ * @param[out] pk Mayo public key
+ * @param[out] sk Mayo secret key
+ * @return int status code
+ */
+int mayo_keypair(const mayo_params_t *p, unsigned char *pk, unsigned char *sk);
+
+/**
+ * MAYO signature generation.
+ *
+ * The implementation performs Mayo.expandSK() + Mayo.sign() in the Mayo spec.
+ * Keys provided is a compacted secret keys.
+ * The caller is responsible to allocate sufficient memory to hold sm.
+ *
+ * @param[in] p Mayo parameter set
+ * @param[out] sm Signature concatenated with message
+ * @param[out] smlen Pointer to the length of sm
+ * @param[in] m Message to be signed
+ * @param[in] mlen Message length
+ * @param[in] sk Compacted secret key
+ * @return int status code
+ */
+int mayo_sign(const mayo_params_t *p, unsigned char *sm,
+              unsigned long long *smlen, const unsigned char *m,
+              unsigned long long mlen, const unsigned char *sk);
+
+/**
+ * Mayo open signature.
+ *
+ * The implementation performs Mayo.verify(). If the signature verification succeeded, the original message is stored in m.
+ * Keys provided is a compact public key.
+ * The caller is responsible to allocate sufficient memory to hold m.
+ *
+ * @param[in] p Mayo parameter set
+ * @param[out] m Message stored if verification succeeds
+ * @param[out] mlen Pointer to the length of m
+ * @param[in] sm Signature concatenated with message
+ * @param[in] smlen Length of sm
+ * @param[in] pk Compacted public key
+ * @return int status code
+ */
+int mayo_open(const mayo_params_t *p, unsigned char *m,
+              unsigned long long *mlen, const unsigned char *sm,
+              unsigned long long smlen, const unsigned char *pk);
+
+/**
+ * Mayo compact keypair generation.
+ *
+ * The implementation corresponds to Mayo.CompactKeyGen() in the Mayo spec.
+ * The caller is responsible to allocate sufficient memory to hold pk and sk.
+ * 
+ * outputs a pair (csk, cpk) \in B^{csk_bytes} x B^{cpk_bytes}, where csk and
+ * cpk are compact representations of a Mayo secret key and public key
+ *
+ * @param[in] p Mayo parameter set
+ * @param[out] cpk Mayo compacted public key
+ * @param[out] csk Mayo compacted secret key
+ * @return int status code
+ */
+int mayo_keypair_compact(const mayo_params_t *p, unsigned char *cpk,
+                         unsigned char *csk);
+
+/**
+ * Mayo expand public key.
+ *
+ * The implementation corresponds to Mayo.expandPK() in the Mayo spec.
+ * The caller is responsible to allocate sufficient memory to hold epk.
+ *
+ * @param[in] p Mayo parameter set
+ * @param[in] cpk Compacted public key.
+ * @param[out] epk Expanded public key.
+ * @return int return code
+ */
+int mayo_expand_pk(const mayo_params_t *p, const unsigned char *cpk,
+                   unsigned char *epk);
+
+/**
+ * Mayo expand secret key.
+ *
+ * The implementation corresponds to Mayo.expandSK() in the Mayo spec.
+ * The caller is responsible to allocate sufficient memory to hold esk.
+ *
+ * @param[in] p Mayo parameter set
+ * @param[in] csk Compacted secret key.
+ * @param[out] esk Expanded secret key.
+ * @return int return code
+ */
+int mayo_expand_sk(const mayo_params_t *p, const unsigned char *csk,
+                   sk_t *esk);
+
+
+/**
+ * Mayo verify signature.
+ *
+ * The implementation performs Mayo.verify(). If the signature verification succeeded, returns 0, otherwise 1.
+ * Keys provided is a compact public key.
+ *
+ * @param[in] p Mayo parameter set
+ * @param[out] m Message stored if verification succeeds
+ * @param[out] mlen Pointer to the length of m
+ * @param[in] sig Signature
+ * @param[in] siglen Length of sig
+ * @param[in] pk Compacted public key
+ * @return int 0 if verification succeeded, 1 otherwise.
+ */
+int mayo_verify(const mayo_params_t *p, const unsigned char *m,
+                unsigned long long mlen, const unsigned char *sig,
+                const unsigned char *pk);
+
+#endif

--- a/crypto_sign/mayo3/ref/mem.c
+++ b/crypto_sign/mayo3/ref/mem.c
@@ -1,0 +1,1 @@
+../../mayo1/ref/mem.c

--- a/crypto_sign/mayo3/ref/mem.h
+++ b/crypto_sign/mayo3/ref/mem.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/mem.h

--- a/crypto_sign/mayo3/ref/params.c
+++ b/crypto_sign/mayo3/ref/params.c
@@ -1,0 +1,1 @@
+../../mayo1/ref/params.c

--- a/crypto_sign/mayo3/ref/rng.h
+++ b/crypto_sign/mayo3/ref/rng.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/rng.h

--- a/crypto_sign/mayo3/ref/simple_arithmetic.h
+++ b/crypto_sign/mayo3/ref/simple_arithmetic.h
@@ -1,0 +1,1 @@
+../../mayo1/ref/simple_arithmetic.h


### PR DESCRIPTION
https://github.com/mupq/pqm4/issues/279

This adds the implementations from
 - ref: https://github.com/PQCMayo/MAYO-C
 - m4f: https://github.com/PQCMayo/MAYO-M4

They are described in https://eprint.iacr.org/2023/1683.
The paper additionally describes a faster variant using a different key representation (nibble-sliced rather than bitsliced). However, that change is not compatible with the round-1 spec and, hence, is not included in this PR. Once the change is officially made in a later MAYO version, we can include it in pqm4. 