### PR TITLE
Add PERK

### DIFF
--- a/crypto_sign/perk-128-fast-3/ref/api.h
+++ b/crypto_sign/perk-128-fast-3/ref/api.h
@@ -1,0 +1,28 @@
+
+/**
+ * @file api.h
+ * @brief NIST SIGN API
+ */
+
+#ifndef SIG_PERK_API_H
+#define SIG_PERK_API_H
+
+#include "parameters.h"
+#include <stddef.h>
+
+#define CRYPTO_ALGNAME "PERK"
+
+#define CRYPTO_PUBLICKEYBYTES PUBLIC_KEY_BYTES
+#define CRYPTO_SECRETKEYBYTES PRIVATE_KEY_BYTES
+#define CRYPTO_BYTES          SIGNATURE_BYTES
+
+// As a technicality, the public key is appended to the secret key in order to respect the NIST API.
+// Without this constraint, CRYPTO_SECRETKEYBYTES would be defined as SECURITY_BYTES
+
+int crypto_sign_keypair(unsigned char *pk, unsigned char *sk);
+int crypto_sign(unsigned char *sm, size_t *smlen, const unsigned char *m, size_t mlen,
+                const unsigned char *sk);
+int crypto_sign_open(unsigned char *m, size_t *mlen, const unsigned char *sm, size_t smlen,
+                     const unsigned char *pk);
+
+#endif

--- a/crypto_sign/perk-128-fast-3/ref/arithmetic.c
+++ b/crypto_sign/perk-128-fast-3/ref/arithmetic.c
@@ -1,0 +1,160 @@
+
+/**
+ * @file arithmetic.c
+ * @brief Implementation of arithmetic related functions
+ */
+
+#include "arithmetic.h"
+#include <stdint.h>
+#include <string.h>
+#include "permutation.h"
+#include "symmetric.h"
+
+static inline int16_t caddq(int16_t a) {
+    a += (a >> 15U) & PARAM_Q;  // NOLINT(hicpp-signed-bitwise): behavior tested in unit tests
+    return a;
+}
+
+static uint16_t multiplicativeInverse(uint16_t a) {
+    // assume a != 0
+    // compute a^(q-2) mod q
+    uint16_t result = 1;
+    uint16_t exponent = PARAM_Q - 2;
+
+    while (exponent > 0) {
+        if ((exponent & 0x1) == 1) {
+            result = sig_perk_barrett_reduce32((uint32_t)result * (uint32_t)a);
+        }
+        a = sig_perk_barrett_reduce32((uint32_t)a * (uint32_t)a);
+        exponent >>= 1;
+    }
+
+    return result;
+}
+
+int sig_perk_vect1_compute_rank(vect1_t in[PARAM_T]) {
+    int rank = 0;
+    int row, col;
+
+    vect1_t x[PARAM_T];
+    memcpy(x, in, sizeof(vect1_t) * PARAM_T);
+    for (col = 0; col < PARAM_N1; col++) {
+        int pivot_found = 0;
+
+        // Find a non-zero pivot in the current column
+        for (int i = rank; i < PARAM_T; i++) {
+            if (x[i][col] != 0) {
+                row = i;
+                pivot_found = 1;
+                break;
+            }
+        }
+
+        if (pivot_found) {
+            // Swap the current row with the row containing the pivot
+            for (int i = 0; i < PARAM_N1; i++) {
+                int temp = x[rank][i];
+                x[rank][i] = x[row][i];
+                x[row][i] = temp;
+            }
+
+            // Perform row operations to eliminate entries below the pivot
+            for (row = rank + 1; row < PARAM_T; row++) {
+                uint16_t multiplier =
+                    sig_perk_barrett_reduce32((uint32_t)x[row][col] * (uint32_t)multiplicativeInverse(x[rank][col]));
+                for (int i = col; i < PARAM_N1; i++) {
+                    x[row][i] -= sig_perk_barrett_reduce32((uint32_t)multiplier * (uint32_t)x[rank][i]);
+                }
+            }
+            rank++;
+        }
+        if (rank == PARAM_T)
+            break;
+    }
+    return rank;
+}
+
+void sig_perk_vect1_add(uint16_t *o, const uint16_t *v1, const uint16_t *v2) {
+    for (uint16_t i = 0; i < PARAM_N1; ++i) {
+        // we assume v1 and v2 already reduced
+        o[i] = caddq((int16_t)((int16_t)v1[i] + (int16_t)v2[i] - PARAM_Q));
+    }
+}
+
+void sig_perk_vect1_mult_scalar_vect(vect1_t output, const uint16_t scalar, const vect1_t input) {
+    for (uint16_t i = 0; i < PARAM_N1; ++i) {
+        output[i] = sig_perk_barrett_reduce32((uint32_t)scalar * (uint32_t)input[i]);
+    }
+}
+
+void sig_perk_vect1_set_random_list(vect1_t output[PARAM_T], const uint8_t seed[SEED_BYTES]) {
+    sig_perk_prg_state_t prg;
+    uint16_t rnd_buff[PRNG_BLOCK_SIZE / 2];
+    // initialize prg
+    sig_perk_prg_init(&prg, PRG1, NULL, seed);
+    // generate randomness
+    int i = 0, rank;
+    do {
+        while (i < PARAM_N1 * PARAM_T) {
+            int j = 0;
+            sig_perk_prg(&prg, (uint8_t *)rnd_buff, sizeof(rnd_buff));
+            while ((i < PARAM_N1 * PARAM_T) && (j < PRNG_BLOCK_SIZE / 2)) {
+                output[i / PARAM_N1][i % PARAM_N1] = PARAM_Q_MASK & rnd_buff[j++];
+                if (output[i / PARAM_N1][i % PARAM_N1] < PARAM_Q) {  // accept the sample
+                    i++;
+                }
+            }
+        }
+        // make sure the vectors x are linearly independent
+        rank = sig_perk_vect1_compute_rank(output);
+    } while (rank != PARAM_T);
+}
+
+void sig_perk_vect2_add(vect2_t o, const vect2_t v1, const vect2_t v2) {
+    for (uint16_t i = 0; i < PARAM_M; ++i) {
+        // we assume v1 and v2 already reduced
+        o[i] = caddq((int16_t)((int16_t)v1[i] + (int16_t)v2[i] - PARAM_Q));
+    }
+}
+
+void sig_perk_vect2_sub(vect2_t o, const vect2_t v1, const vect2_t v2) {
+    for (uint16_t i = 0; i < PARAM_M; ++i) {
+        o[i] = caddq((int16_t)((int16_t)v1[i] - (int16_t)v2[i]));
+    }
+}
+
+void sig_perk_vect2_mult_scalar_vect(vect2_t output, const uint16_t scalar, const vect2_t input) {
+    for (uint16_t i = 0; i < PARAM_M; ++i) {
+        output[i] = sig_perk_barrett_reduce32((uint32_t)scalar * (uint32_t)input[i]);
+    }
+}
+
+void sig_perk_mat_set_random(mat_t m_output, const uint8_t seed[SEED_BYTES]) {
+    sig_perk_prg_state_t prg;
+    uint16_t rnd_buff[PRNG_BLOCK_SIZE / 2];
+    // initialize prg
+    sig_perk_prg_init(&prg, PRG1, NULL, seed);
+    // generate randomness
+    int j = 0;
+    while (j < PARAM_M * PARAM_N1) {
+        int k = 0;
+        sig_perk_prg(&prg, (uint8_t *)rnd_buff, sizeof(rnd_buff));
+        while ((j < PARAM_M * PARAM_N1) && (k < PRNG_BLOCK_SIZE / 2)) {
+            m_output[j / PARAM_N1][j % PARAM_N1] = PARAM_Q_MASK & rnd_buff[k++];
+            if (m_output[j / PARAM_N1][j % PARAM_N1] < PARAM_Q) {  // accept the sample
+                j++;
+            }
+        }
+    }
+}
+
+void sig_perk_mat_vect_mul(vect2_t output, const mat_t m_input, const vect1_t v_input) {
+    uint32_t tmp = 0;
+    for (int i = 0; i < PARAM_M; ++i) {
+        for (int j = 0; j < PARAM_N1; ++j) {
+            tmp += ((uint32_t)m_input[i][j]) * ((uint32_t)v_input[j]);
+        }
+        output[i] = sig_perk_barrett_reduce32(tmp);
+        tmp = 0;
+    }
+}

--- a/crypto_sign/perk-128-fast-3/ref/arithmetic.h
+++ b/crypto_sign/perk-128-fast-3/ref/arithmetic.h
@@ -1,0 +1,155 @@
+
+/**
+ * @file arithmetic.h
+ * @brief Header file for arithmetic.c
+ */
+
+#ifndef SIG_PERK_ARITHMETIC_H
+#define SIG_PERK_ARITHMETIC_H
+
+#include <stdint.h>
+#include "parameters.h"
+
+#define SHBIT16 25
+#define SHBIT32 41
+
+/**
+ * @brief Vector vect1_t
+ *
+ * This structure contains a vector of size PARAM_N1
+ */
+typedef uint16_t vect1_t[PARAM_N1];
+
+/**
+ * @brief Vector vect2_t
+ *
+ * This structure contains a vector of size PARAM_M
+ */
+typedef uint16_t vect2_t[PARAM_M];
+
+/**
+ * @brief Matrix mat_t
+ *
+ * This structure contains a matrix represented as a vector of vectors of type vect1_t
+ */
+typedef vect1_t mat_t[PARAM_M];
+
+/**
+ * @brief perform barrett reduction on a 16 bit input value
+ *        output range 0 <= out < PARAM_Q
+ *        input range:
+ *            - PARAM_Q == 1021: 0 <= a <= 65535 (0xFFFF)
+ *
+ * @param a 16 bit input
+ * @return uint16_t output
+ */
+static inline uint16_t sig_perk_barrett_reduce16(uint16_t a) {
+    uint16_t t;
+    const uint32_t v = ((((uint32_t)1U << SHBIT16) / PARAM_Q));
+
+    t = ((v * a + v) >> SHBIT16);  // NOLINT(hicpp-signed-bitwise): tested in unit tests
+    t *= PARAM_Q;
+    return (uint16_t)(a - t);
+}
+
+/**
+ * @brief perform barrett reduction on a 32 bit input value
+ *        output range 0 <= out < PARAM_Q
+ *        input range:
+ *            - PARAM_Q == 1021: 0 <= a <= 4294967295 (0xFFFFFFFF)
+ *
+ * @param a 32 bit input value
+ * @return uint16_t output
+ */
+static inline uint16_t sig_perk_barrett_reduce32(uint32_t a) {
+    uint32_t t;
+    const uint64_t v = (((uint64_t)1U << SHBIT32) / PARAM_Q);
+
+    t = ((v * a + v) >> SHBIT32);  // NOLINT(hicpp-signed-bitwise): tested in unit tests
+    t *= PARAM_Q;
+    return (uint16_t)(a - t);
+}
+
+/**
+ * @brief Add in Fq two vect1_t vectors
+ *
+ * @details The prototype of this function differs from the others in this file due to
+ *          a false positive warning with GCC 13 (-Wstringop-overflow) when compiling with -O3.
+ *
+ * @param [out] o a vector containing the result
+ * @param [in] v1 a vector
+ * @param [in] v2 a vector
+ */
+void sig_perk_vect1_add(uint16_t *o, const uint16_t *v1, const uint16_t *v2);
+
+/**
+ * @brief Multiplication in Fq of a vect1_t vector by a scalar
+ *
+ * @param [out] output vector containing the result
+ * @param [in] scalar a scalar in Fq
+ * @param [in] input a vector of type vect1_t
+ */
+void sig_perk_vect1_mult_scalar_vect(vect1_t output, const uint16_t scalar, const vect1_t input);
+
+/**
+ * @brief Given a list of PARAM_T vectors vect1_t, compute the rank of the matrix
+ * formed by these. Used to test the linear dependence.
+ *
+ * @param [in] x list of vectors to be seen as a matrix
+ * @returns the rank of the matrix
+ */
+int sig_perk_vect1_compute_rank(vect1_t x[PARAM_T]);
+
+/**
+ * @brief Sample uniformly at random a list of PARAM_T vect1_t vectors in Fq
+ *
+ * @param [out] output an array of vectors vect1_t containing the result
+ * @param [in] seed a seed
+ */
+void sig_perk_vect1_set_random_list(vect1_t output[PARAM_T], const uint8_t seed[SEED_BYTES]);
+
+/**
+ * @brief Add in Fq two vect2_t vectors
+ *
+ * @param [out] o a vector containing the result
+ * @param [in] v1 a vector
+ * @param [in] v2 a vector
+ */
+void sig_perk_vect2_add(vect2_t o, const vect2_t v1, const vect2_t v2);
+
+/**
+ * @brief Subtract in Fq two vect2_t vectors
+ *
+ * @param [out] o vector containing the result
+ * @param [in] v1 vector
+ * @param [in] v2 vector
+ */
+void sig_perk_vect2_sub(vect2_t o, const vect2_t v1, const vect2_t v2);
+
+/**
+ * @brief Multiplication in Fq of a vect2_t vector by a scalar
+ *
+ * @param [out] output vector containing the result
+ * @param [in] scalar a scalar in Fq
+ * @param [in] input a vector of type vect2_t
+ */
+void sig_perk_vect2_mult_scalar_vect(vect2_t output, const uint16_t scalar, const vect2_t input);
+
+/**
+ * @brief Generate a (PARAM_M x PARAM_N1) random matrix in Fq
+ *
+ * @param [out] m_output a matrix
+ * @param [in] seed a seed used to initialize a PRNG
+ */
+void sig_perk_mat_set_random(mat_t m_output, const uint8_t seed[SEED_BYTES]);
+
+/**
+ * @brief Compute a matrix vector multiplication in Fq
+ *
+ * @param [out] output a vector
+ * @param [in] m_input a matrix
+ * @param [in] v_input a vector
+ */
+void sig_perk_mat_vect_mul(vect2_t output, const mat_t m_input, const vect1_t v_input);
+
+#endif

--- a/crypto_sign/perk-128-fast-3/ref/common.c
+++ b/crypto_sign/perk-128-fast-3/ref/common.c
@@ -1,0 +1,94 @@
+
+/**
+ * @file common.c
+ * @brief Common functions
+ */
+
+#include "common.h"
+#include <string.h>
+#include "crypto_memset.h"
+#include "symmetric.h"
+
+void sig_perk_gen_pi_i_and_v_i(perm_t *pi_i, vect1_t *v_i, const salt_t salt,
+                               const perk_theta_seeds_tree_t theta_tree) {
+    sig_perk_prg_state_t state;
+    uint16_t rnd_buffer_pi_i[PARAM_N1];
+    uint16_t rnd_buff_v_i[PRNG_BLOCK_SIZE / 2];
+    for (int i = 0; i < PARAM_N; ++i) {
+        sig_perk_prg_init(&state, PRG1, salt, theta_tree[THETA_SEEDS_OFFSET + i]);
+        if (i != 0) {  // skip the generation of pi_1
+            sig_perk_prg(&state, (uint8_t *)rnd_buffer_pi_i, sizeof(rnd_buffer_pi_i));
+            while (sig_perk_perm_gen_given_random_input(pi_i[i], rnd_buffer_pi_i) != EXIT_SUCCESS) {
+                sig_perk_prg(&state, (uint8_t *)rnd_buffer_pi_i, sizeof(rnd_buffer_pi_i));
+            }
+        }
+        // To make easier the times4 optimized implementation
+        // we reinitialise the PRNG with a different domain separator, thus we use
+        // PRG1 to sample the pi_i and PRG2 to sample the v_i
+        sig_perk_prg_init(&state, PRG2, salt, theta_tree[THETA_SEEDS_OFFSET + i]);
+        int j = 0;
+        while (j < PARAM_N1) {
+            int k = 0;
+            sig_perk_prg(&state, (uint8_t *)rnd_buff_v_i, sizeof(rnd_buff_v_i));
+            while ((j < PARAM_N1) && (k < PRNG_BLOCK_SIZE / 2)) {
+                v_i[i][j] = PARAM_Q_MASK & rnd_buff_v_i[k++];
+                if (v_i[i][j] < PARAM_Q) {  // accept the sample
+                    j++;
+                }
+            }
+        }
+    }
+    memset_zero(rnd_buffer_pi_i, sizeof(rnd_buffer_pi_i));
+    memset_zero(rnd_buff_v_i, sizeof(rnd_buff_v_i));
+}
+
+void sig_perk_gen_vect_v(vect1_t o, perm_t *pi_i, vect1_t *v_i, const perm_t pi) {
+    vect1_t tmp_vect;
+    perm_t tmp_compose_perm;
+
+    sig_perk_perm_compose_inv(tmp_compose_perm, pi, pi_i[0]);
+    sig_perk_perm_vect_permute(o, tmp_compose_perm, v_i[0]);
+    for (int i = 1; i < PARAM_N - 1; ++i) {
+        sig_perk_perm_compose_inv(tmp_compose_perm, tmp_compose_perm, pi_i[i]);
+        sig_perk_perm_vect_permute(tmp_vect, tmp_compose_perm, v_i[i]);
+        sig_perk_vect1_add(o, o, tmp_vect);
+    }
+    sig_perk_vect1_add(o, o, v_i[PARAM_N - 1]);
+}
+
+void sig_perk_gen_commitment_cmt_1_i(perk_instance_t *instance, salt_t salt, uint8_t tau) {
+    for (int i = 0; i < PARAM_N; ++i) {
+        sig_perk_hash_state_t state;
+        uint8_t idx = i;
+        if (i == 0) {
+            uint8_t pi_1_bytes[PARAM_N1];
+            for (int j = 0; j < PARAM_N1; ++j) {
+                pi_1_bytes[j] = (uint8_t)instance->pi_i[0][j];
+            }
+            sig_perk_hash_init(&state, salt, &tau, &idx);
+            sig_perk_hash_update(&state, pi_1_bytes, PARAM_N1);
+            sig_perk_hash_update(&state, instance->theta_tree[THETA_SEEDS_OFFSET], sizeof(theta_t));
+            sig_perk_hash_final(&state, instance->cmt_1_i[0], H0);
+        } else {
+            sig_perk_hash_init(&state, salt, &tau, &idx);
+            sig_perk_hash_update(&state, instance->theta_tree[THETA_SEEDS_OFFSET + i], sizeof(theta_t));
+            sig_perk_hash_final(&state, instance->cmt_1_i[i], H0);
+        }
+    }
+}
+
+void sig_perk_gen_instance_commitments(perk_instance_t *instance, salt_t salt, uint8_t tau, const perm_t pi) {
+    sig_perk_gen_pi_i_and_v_i(instance->pi_i, instance->v_i, salt, (const theta_t *)instance->theta_tree);
+    sig_perk_perm_gen_pi_1(instance->pi_i, pi);
+    sig_perk_gen_commitment_cmt_1_i(instance, salt, tau);
+}
+
+void sig_perk_gen_instance_commitment_cmt_1(perk_instance_t *instance, const salt_t salt, uint8_t tau, const mat_t H,
+                                            const vect1_t v) {
+    sig_perk_hash_state_t state;
+    vect2_t tmp;
+    sig_perk_mat_vect_mul(tmp, H, v);
+    sig_perk_hash_init(&state, salt, &tau, NULL);
+    sig_perk_hash_update(&state, (uint8_t *)tmp, sizeof(tmp));
+    sig_perk_hash_final(&state, instance->cmt_1, H0);
+}

--- a/crypto_sign/perk-128-fast-3/ref/common.h
+++ b/crypto_sign/perk-128-fast-3/ref/common.h
@@ -1,0 +1,65 @@
+
+/**
+ * @file common.h
+ * @brief Header file for common.c
+ */
+
+#ifndef SIG_PERK_COMMON_H
+#define SIG_PERK_COMMON_H
+
+#include "data_structures.h"
+#include "permutation.h"
+#include "symmetric.h"
+
+/**
+ * @brief Generate a set of pi_i and v_i
+ *
+ * @param [out] pi_i a pointer to permutations
+ * @param [out] v_i a pointer to vectors v_i
+ * @param [in] salt a salt
+ * @param [in] theta_tree a tree of seeds
+ */
+void sig_perk_gen_pi_i_and_v_i(perm_t *pi_i, vect1_t *v_i, const salt_t salt, const perk_theta_seeds_tree_t theta_tree);
+
+/**
+ * @brief Generate the vector v
+ *
+ * @param [out] o a variable containing the vector v
+ * @param [in] pi_i a pointer to permutations pi_i
+ * @param [in] v_i a pointer to vectors v_i
+ * @param [in] pi a variable containing the secret permutation pi
+ */
+void sig_perk_gen_vect_v(vect1_t o, perm_t *pi_i, vect1_t *v_i, const perm_t pi);
+
+/**
+ * @brief Compute commitments cmt_1,i (for i in 1,...,N) for one round of the scheme
+ *
+ * @param [out,in] instance pointer to struct instance
+ * @param [in] salt a salt
+ * @param [in] tau an integer that is the index in 0,...,tau
+ */
+void sig_perk_gen_commitment_cmt_1_i(perk_instance_t *instance, salt_t salt, uint8_t tau);
+
+/**
+ * @brief Generate commitments cmt_1,i (for i in 1,...,N) for one round of the scheme
+ *
+ * @param [out,in] instance a pointer to an instance
+ * @param [in] salt a salt
+ * @param [in] tau an integer that is the index in 0,...,tau
+ * @param [in] pi a variable containing the secret permutation pi
+ */
+void sig_perk_gen_instance_commitments(perk_instance_t *instance, salt_t salt, uint8_t tau, const perm_t pi);
+
+/**
+ * @brief Compute commitment cmt_1 for one round of the scheme
+ *
+ * @param [out,in] instance a pointer to an instance
+ * @param [in] salt a salt
+ * @param [in] tau an integer that is the index in 0,...,tau
+ * @param [in] H a variable containing the public matrix H
+ * @param [in] v a variable containing to vectors v_i
+ */
+void sig_perk_gen_instance_commitment_cmt_1(perk_instance_t *instance, const salt_t salt, uint8_t tau, const mat_t H,
+                                            const vect1_t v);
+
+#endif

--- a/crypto_sign/perk-128-fast-3/ref/crypto_memset.c
+++ b/crypto_sign/perk-128-fast-3/ref/crypto_memset.c
@@ -1,0 +1,22 @@
+
+/**
+ * @file crypto_memset.c
+ * @brief cryptographic utility functions
+ */
+
+#include "crypto_memset.h"
+
+void *(*volatile memset_volatile)(void *, int, size_t) = memset;
+
+int cmp_const(const void *a, const void *b, const size_t size) {
+    const unsigned char *_a = (const unsigned char *)a;
+    const unsigned char *_b = (const unsigned char *)b;
+    unsigned char result = 0;
+    size_t i;
+
+    for (i = 0; i < size; i++) {
+        result |= _a[i] ^ _b[i];
+    }
+
+    return result; /* returns 0 if equal, nonzero otherwise */
+}

--- a/crypto_sign/perk-128-fast-3/ref/crypto_memset.h
+++ b/crypto_sign/perk-128-fast-3/ref/crypto_memset.h
@@ -1,0 +1,24 @@
+
+/**
+ * @file crypto_memset.h
+ * @brief Header file for cryptographic utility functions
+ */
+
+#ifndef CRYPTO_MEMSET_H
+#define CRYPTO_MEMSET_H
+
+#include <string.h>
+
+/**
+ * safer call to memset https://github.com/veorq/cryptocoding#problem-4
+ */
+extern void *(*volatile memset_volatile)(void *, int, size_t);
+
+/**
+ * constant time call to memcmp
+ */
+int cmp_const(const void *a, const void *b, const size_t size);
+
+#define memset_zero(ptr, len) memset_volatile((ptr), 0, (len))
+
+#endif  // CRYPTO_MEMSET_H

--- a/crypto_sign/perk-128-fast-3/ref/data_structures.h
+++ b/crypto_sign/perk-128-fast-3/ref/data_structures.h
@@ -1,0 +1,117 @@
+
+/**
+ * @file data_structures.h
+ * @brief common data structures for the scheme
+ */
+
+#ifndef SIG_PERK_DATA_STRUCTURES_H
+#define SIG_PERK_DATA_STRUCTURES_H
+
+#include <stdint.h>
+#include "arithmetic.h"
+#include "parameters.h"
+#include "permutation.h"
+#include "symmetric.h"
+#include "theta_tree.h"
+
+/**
+ * @brief Commitment cmt_t
+ *
+ * This structure contains a commitment
+ */
+typedef uint8_t cmt_t[COMMITMENT_BYTES];
+
+/** @struct perk_public_key_t
+ *  @brief This structure contains the public key
+ *  @var perk_public_key_t::seed
+ *  Member 'seed' is an array of bytes used to generate the public key
+ *  @var perk_public_key_t::H
+ *  Member 'H' is a matrix
+ *  @var perk_public_key_t::x
+ *  Member 'x' is a vector of vectors
+ *  @var perk_public_key_t::y
+ *  Member 'y' is a vector of vectors
+ */
+typedef struct {
+    uint8_t seed[SEED_BYTES];
+    mat_t H;
+    vect1_t x[PARAM_T];
+    vect2_t y[PARAM_T];
+} perk_public_key_t;
+
+/** @struct perk_private_key_t
+ *  @brief This structure contains the private key
+ *  @var perk_private_key_t::seed
+ *  Member 'seed' is an array of bytes used to generate the private key
+ *  @var perk_private_key_t::pi
+ *  Member 'pi' is a permutation
+ *  @var perk_private_key_t::pk_bytes
+ *  Member 'pk_bytes' is an array of bytes that contain the public key
+ */
+typedef struct {
+    uint8_t seed[SEED_BYTES];
+    perm_t pi;
+    uint8_t pk_bytes[PUBLIC_KEY_BYTES];
+} perk_private_key_t;
+
+/** @struct perk_instance_t
+ *  @brief This structure contains an instance of one round of the scheme
+ *  @var perk_instance_t::theta_tree
+ *  Member 'theta_tree' is a seed tree containing theta and the theta_i
+ *  @var perk_instance_t::pi_i
+ *  Member 'pi_i' is a permutation
+ *  @var perk_instance_t::v_i
+ *  Member 'v_i' is an array of vectors
+ *  @var perk_instance_t::s_i
+ *  Member 's_i' is an array of vectors
+ *  @var perk_instance_t::cmt_1_i
+ *  Member 'cmt_1_i' is an array of commitments
+ *  @var perk_instance_t::cmt_1
+ *  Member 'cmt_1' is a commitment
+ */
+typedef struct {
+    perk_theta_seeds_tree_t theta_tree;
+    perm_t pi_i[PARAM_N];
+    vect1_t v_i[PARAM_N];
+    vect1_t s_i[PARAM_N + 1];
+    cmt_t cmt_1_i[PARAM_N];
+    cmt_t cmt_1;
+} perk_instance_t;
+
+/** @struct perk_response_t
+ *  @brief This structure contains the response
+ *  @var perk_response_t::z1
+ *  Member 'z1' is a vector
+ *  @var perk_response_t::z2_pi
+ *  Member 'z2_pi' is a permutation
+ *  @var perk_response_t::z2_theta
+ *  Member 'z2_theta' is an array of theta_t
+ *  @var perk_response_t::cmt_1_alpha
+ *  Member 'cmt_1_alpha' is commitment
+ */
+typedef struct {
+    vect1_t z1;
+    perm_t z2_pi;
+    theta_t z2_theta[THETA_TREE_LEVELS];
+    cmt_t cmt_1_alpha;
+} perk_response_t;
+
+/** @struct perk_signature_t
+ *  @brief This structure contains the signature
+ *  @var perk_signature_t::salt
+ *  Member 'salt' is a salt
+ *  @var perk_signature_t::h1
+ *  Member 'h1' is a digest
+ *  @var perk_signature_t::h2
+ *  Member 'h2' is a digest
+ *  @var perk_signature_t::responses
+ *  Member 'responses' is an array of perk_response_t
+ */
+typedef struct {
+    salt_t salt;
+    digest_t h1;
+    digest_t h2;
+    perk_response_t responses[PARAM_TAU];
+} perk_signature_t;
+
+#endif

--- a/crypto_sign/perk-128-fast-3/ref/djbsort.c
+++ b/crypto_sign/perk-128-fast-3/ref/djbsort.c
@@ -1,0 +1,12 @@
+#include "djbsort.h"
+
+/* can save time by vectorizing xor loops */
+/* can save time by integrating xor loops with int32_sort */
+
+void uint32_sort(uint32_t *x,long long n)
+{
+  long long j;
+  for (j = 0;j < n;++j) x[j] ^= 0x80000000;
+  int32_sort((int32_t *) x,n);
+  for (j = 0;j < n;++j) x[j] ^= 0x80000000;
+}

--- a/crypto_sign/perk-128-fast-3/ref/djbsort.h
+++ b/crypto_sign/perk-128-fast-3/ref/djbsort.h
@@ -1,0 +1,15 @@
+
+/**
+ * @file djbsort.h
+ * @brief Header file for sorting functions
+ */
+
+#ifndef DJB_SORT_H
+#define DJB_SORT_H
+
+#include <stdint.h>
+
+extern void uint32_sort(uint32_t *, long long) __attribute__((visibility("default")));
+extern void int32_sort(int32_t *, long long) __attribute__((visibility("default")));
+
+#endif

--- a/crypto_sign/perk-128-fast-3/ref/int32_minmax.inc
+++ b/crypto_sign/perk-128-fast-3/ref/int32_minmax.inc
@@ -1,0 +1,10 @@
+#define int32_MINMAX(a,b) \
+do { \
+  int32 ab = b ^ a; \
+  int32 c = b - a; \
+  c ^= ab & (c ^ b); \
+  c >>= 31; \
+  c &= ab; \
+  a ^= c; \
+  b ^= c; \
+} while(0)

--- a/crypto_sign/perk-128-fast-3/ref/keygen.c
+++ b/crypto_sign/perk-128-fast-3/ref/keygen.c
@@ -1,0 +1,46 @@
+
+/**
+ * @file keygen.c
+ * @brief Implementation of key generation
+ */
+
+#include "keygen.h"
+#include <string.h>
+#include "arithmetic.h"
+#include "data_structures.h"
+#include "parameters.h"
+#include "parsing.h"
+#include "randombytes.h"
+#include "verbose.h"
+
+uint8_t sig_perk_generate_keypair(perk_public_key_t *pk, perk_private_key_t *sk) {
+    vect1_t tmp;
+    // sample seeds
+    randombytes(pk->seed, sizeof(pk->seed));
+    randombytes(sk->seed, sizeof(sk->seed));
+
+    // sample private key
+    sig_perk_perm_set_random(sk->pi, sk->seed);
+
+    // sample public matrix H
+    sig_perk_mat_set_random(pk->H, pk->seed);
+    // sample public vector x
+    sig_perk_vect1_set_random_list(pk->x, pk->seed);
+    // compute y
+    for (int i = 0; i < PARAM_T; i++) {
+        // compute tmp = pi(x)
+        sig_perk_perm_vect_permute(tmp, sk->pi, pk->x[i]);
+        sig_perk_mat_vect_mul(pk->y[i], (const vect1_t *)pk->H, tmp);
+    }
+
+    sig_perk_public_key_to_bytes(sk->pk_bytes, pk);
+
+    SIG_PERK_VERBOSE_PRINT_uint8_t_array("sk_seed", sk->seed, SEED_BYTES);
+    SIG_PERK_VERBOSE_PRINT_uint8_t_array("pi", sk->pi, PARAM_N1);
+    SIG_PERK_VERBOSE_PRINT_uint8_t_array("pk_seed", pk->seed, SEED_BYTES);
+    SIG_PERK_VERBOSE_PRINT_matrix((const vect1_t *)pk->H);
+    SIG_PERK_VERBOSE_PRINT_x((const vect1_t *)pk->x);
+    SIG_PERK_VERBOSE_PRINT_y((const vect2_t *)pk->y);
+
+    return EXIT_SUCCESS;
+}

--- a/crypto_sign/perk-128-fast-3/ref/keygen.h
+++ b/crypto_sign/perk-128-fast-3/ref/keygen.h
@@ -1,0 +1,21 @@
+
+/**
+ * @file keygen.h
+ * @brief Header file for keygen.c
+ */
+
+#ifndef SIG_PERK_KEYGEN_H
+#define SIG_PERK_KEYGEN_H
+
+#include "data_structures.h"
+
+/**
+ * @brief Generate a key pair
+ *
+ * @param [out] pk a pointer to public key structure
+ * @param [out] sk a pointer to private key structure
+ * @return int 0 if the key generation is successful
+ */
+uint8_t sig_perk_generate_keypair(perk_public_key_t *pk, perk_private_key_t *sk);
+
+#endif

--- a/crypto_sign/perk-128-fast-3/ref/parameters.h
+++ b/crypto_sign/perk-128-fast-3/ref/parameters.h
@@ -1,0 +1,43 @@
+
+/**
+ * @file parameters.h
+ * @brief Parameters of the PERK scheme
+ */
+
+#ifndef SIG_PERK_PARAMETER_H
+#define SIG_PERK_PARAMETER_H
+
+#define SECURITY_BYTES 16 /**< Number of bytes for the expected security level */
+#define PARAM_N1       79 /**< Parameter n of the scheme */
+#define PARAM_M        35 /**< Parameter m of the scheme */
+#define PARAM_T        3  /**< Parameter t of the scheme */
+#define PARAM_TAU      30 /**< Parameter tau of the scheme */
+
+#define PARAM_N           32 /**< Parameter N of the scheme */
+#define THETA_TREE_LEVELS 5  /**< The number of levels of the theta tree i.e log2(PARAM_N) */
+
+#define PARAM_Q      1021 /**< Parameter q of the scheme */
+#define PARAM_Q_BITS 10   /**< Number of bits needed to represent PARAM_Q */
+
+#define PARAM_N_MASK ((1U << THETA_TREE_LEVELS) - 1) /**< Mask for bits representing PARAM_N */
+#define PARAM_Q_MASK ((1U << PARAM_Q_BITS) - 1)      /**< Mask for bits representing PARAM_Q */
+
+#define PARAM_N1_BITSx2 13 /**< Bits needed to store two permutation coefficients */
+
+#define SEED_BYTES       SECURITY_BYTES       /**< Seed size used in the scheme */
+#define SALT_BYTES       (2 * SECURITY_BYTES) /**< Salt size used in the scheme */
+#define HASH_BYTES       (2 * SECURITY_BYTES) /**< Hash size used in the scheme */
+#define COMMITMENT_BYTES HASH_BYTES           /**< Commitment size used in the scheme */
+
+#define PUBLIC_KEY_BYTES  (SEED_BYTES + ((PARAM_M * PARAM_Q_BITS * PARAM_T + 7) / 8)) /**< Public key size */
+#define PRIVATE_KEY_BYTES (SEED_BYTES + PUBLIC_KEY_BYTES)                             /**< Private key size */
+
+#define SIGNATURE_BYTES                                                                                      \
+    (SALT_BYTES + (2 * COMMITMENT_BYTES) + (COMMITMENT_BYTES + SEED_BYTES * THETA_TREE_LEVELS) * PARAM_TAU + \
+     ((PARAM_TAU * PARAM_N1 * PARAM_Q_BITS + 7) / 8) +                                                       \
+     ((PARAM_TAU * PARAM_N1 * PARAM_N1_BITSx2 / 2 + 7) / 8)) /**< Signature size */
+
+#define EXIT_FAILURE 1 /**< Exit code in case of failure */
+#define EXIT_SUCCESS 0 /**< Exit code in case of success */
+
+#endif  // SIG_PERK_PARAMETER_H

--- a/crypto_sign/perk-128-fast-3/ref/parsing.c
+++ b/crypto_sign/perk-128-fast-3/ref/parsing.c
@@ -1,0 +1,598 @@
+
+/**
+ * @file parsing.c
+ * @brief Implementation of parsing functions
+ */
+
+#include "parsing.h"
+#include "parameters.h"
+
+#include <string.h>
+#include "arithmetic.h"
+#include "data_structures.h"
+
+#if (PARAM_N1_BITSx2 == 14)
+/**
+ * @brief store a 7 bit value in a byte array at bit position i*7
+ *        must be called sequentially with increasing index
+ *
+ * @param sb  byte array pointer
+ * @param i   position in the byte array
+ * @param val 7 bit value to store
+ */
+static inline void store_7bit_in_bytearray(uint8_t* sb, int i, uint16_t val) {
+    val &= 0x7F;
+    int k = (i * 7) / 8;
+    switch (i % 8) {
+        case 0:
+            sb[k + 0] = val;
+            break;
+        case 1:
+            sb[k + 0] |= val << 7;
+            sb[k + 1] = val >> 1;
+            break;
+        case 2:
+            sb[k + 0] |= val << 6;
+            sb[k + 1] = val >> 2;
+            break;
+        case 3:
+            sb[k + 0] |= val << 5;
+            sb[k + 1] = val >> 3;
+            break;
+        case 4:
+            sb[k + 0] |= val << 4;
+            sb[k + 1] = val >> 4;
+            break;
+        case 5:
+            sb[k + 0] |= val << 3;
+            sb[k + 1] = val >> 5;
+            break;
+        case 6:
+            sb[k + 0] |= val << 2;
+            sb[k + 1] = val >> 6;
+            break;
+        case 7:
+            sb[k + 0] |= val << 1;
+            break;
+    }
+}
+
+/**
+ * @brief load a 7 bit value from a byte array at bit position i*7
+ *
+ * @param sb byte array pointer
+ * @param i  position in the byte array
+ * @return   uint8_t loaded value
+ */
+static inline uint8_t load_7bit_from_bytearray(const uint8_t* sb, int i) {
+    uint8_t val = 0;
+    int k = (i * 7) / 8;
+    switch (i % 8) {
+        case 0:
+            val = (sb[k + 0] & 0x7F);
+            break;
+        case 1:
+            val = sb[k + 0] >> 7;
+            val |= (sb[k + 1] & 0x3F) << 1;
+            break;
+        case 2:
+            val = sb[k + 0] >> 6;
+            val |= (sb[k + 1] & 0x1F) << 2;
+            break;
+        case 3:
+            val = sb[k + 0] >> 5;
+            val |= (sb[k + 1] & 0x0F) << 3;
+            break;
+        case 4:
+            val = sb[k + 0] >> 4;
+            val |= (sb[k + 1] & 0x07) << 4;
+            break;
+        case 5:
+            val = sb[k + 0] >> 3;
+            val |= (sb[k + 1] & 0x03) << 5;
+            break;
+        case 6:
+            val = sb[k + 0] >> 2;
+            val |= (sb[k + 1] & 0x01) << 6;
+            break;
+        case 7:
+            val = sb[k + 0] >> 1;
+            break;
+        default:
+            break;
+    }
+
+    return val;
+}
+#endif
+
+/**
+ * @brief store a 10 bit value in a byte array at bit position i*10
+ *        must be called sequentially with increasing index
+ *
+ * @param sb  byte array pointer
+ * @param i   position in the byte array
+ * @param val 10 bit value to store
+ */
+static inline void store_10bit_in_bytearray(uint8_t* sb, int i, uint16_t val) {
+    val &= 0x3FF;
+    int k = (i / 4) * 5;
+    switch (i % 4) {
+        case 0:
+            sb[k + 0] = val;
+            sb[k + 1] = val >> 8;
+            break;
+        case 1:
+            sb[k + 1] |= val << 2;
+            sb[k + 2] = val >> 6;
+            break;
+        case 2:
+            sb[k + 2] |= val << 4;
+            sb[k + 3] = val >> 4;
+            break;
+        case 3:
+            sb[k + 3] |= val << 6;
+            sb[k + 4] = val >> 2;
+            break;
+        default:
+            break;
+    }
+}
+
+/**
+ * @brief load a 10 bit value from a byte array at bit position i*10
+ *
+ * @param sb byte array pointer
+ * @param i  position in the byte array
+ * @return   uint16_t loaded value
+ */
+static inline uint16_t load_10bit_from_bytearray(const uint8_t* sb, int i) {
+    int k = (i / 4) * 5;
+    uint16_t val = 0;
+    switch (i % 4) {
+        case 0:
+            val = sb[k + 0];
+            val |= ((uint16_t)sb[k + 1] & 0x3) << 8;
+            break;
+        case 1:
+            val = sb[k + 1] >> 2;
+            val |= ((uint16_t)sb[k + 2] & 0xF) << 6;
+            break;
+        case 2:
+            val = sb[k + 2] >> 4;
+            val |= ((uint16_t)sb[k + 3] & 0x3F) << 4;
+            break;
+        case 3:
+            val = sb[k + 3] >> 6;
+            val |= ((uint16_t)sb[k + 4] & 0xFF) << 2;
+            break;
+        default:
+            break;
+    }
+
+    return val;
+}
+
+#if (PARAM_N1_BITSx2 == 13)
+/**
+ * @brief store a 13 bit value in a byte array at bit position i*13
+ *        must be called sequentially with increasing index
+ *
+ * @param sb  byte array pointer
+ * @param i   position in the byte array
+ * @param val 13 bit value to store
+ */
+static inline void store_13bit_in_bytearray(uint8_t* sb, int i, uint16_t val) {
+    val &= 0x1FFF;
+    int k = (i * 13) / 8;
+    switch (i % 8) {
+        case 0:
+            sb[k + 0] = val;
+            sb[k + 1] = val >> 8;
+            break;
+        case 1:
+            sb[k + 0] |= val << 5;
+            sb[k + 1] = val >> 3;
+            sb[k + 2] = val >> 11;
+            break;
+        case 2:
+            sb[k + 0] |= val << 2;
+            sb[k + 1] = val >> 6;
+            break;
+        case 3:
+            sb[k + 0] |= val << 7;
+            sb[k + 1] = val >> 1;
+            sb[k + 2] = val >> 9;
+            break;
+        case 4:
+            sb[k + 0] |= val << 4;
+            sb[k + 1] = val >> 4;
+            sb[k + 2] = val >> 12;
+            break;
+        case 5:
+            sb[k + 0] |= val << 1;
+            sb[k + 1] = val >> 7;
+            break;
+        case 6:
+            sb[k + 0] |= val << 6;
+            sb[k + 1] = val >> 2;
+            sb[k + 2] = val >> 10;
+            break;
+        case 7:
+            sb[k + 0] |= val << 3;
+            sb[k + 1] = val >> 5;
+            break;
+    }
+}
+
+/**
+ * @brief load a 13 bit value from a byte array at bit position i*13
+ *
+ * @param sb byte array pointer
+ * @param i  position in the byte array
+ * @return   uint16_t loaded value
+ */
+static inline uint16_t load_13bit_from_bytearray(const uint8_t* sb, int i) {
+    int k = (i * 13) / 8;
+    uint16_t val = 0;
+    switch (i % 8) {
+        case 0:
+            val = sb[k + 0];
+            val |= ((uint16_t)sb[k + 1] & 0x1F) << 8;
+            break;
+        case 1:
+            val = sb[k + 0] >> 5;
+            val |= ((uint16_t)sb[k + 1] & 0xFF) << 3;
+            val |= ((uint16_t)sb[k + 2] & 0x03) << 11;
+            break;
+        case 2:
+            val = sb[k + 0] >> 2;
+            val |= ((uint16_t)sb[k + 1] & 0x7F) << 6;
+            break;
+        case 3:
+            val = sb[k + 0] >> 7;
+            val |= ((uint16_t)sb[k + 1] & 0xFF) << 1;
+            val |= ((uint16_t)sb[k + 2] & 0x0F) << 9;
+            break;
+        case 4:
+            val = sb[k + 0] >> 4;
+            val |= ((uint16_t)sb[k + 1] & 0xFF) << 4;
+            val |= ((uint16_t)sb[k + 2] & 0x01) << 12;
+            break;
+        case 5:
+            val = sb[k + 0] >> 1;
+            val |= ((uint16_t)sb[k + 1] & 0x3F) << 7;
+            break;
+        case 6:
+            val = sb[k + 0] >> 6;
+            val |= ((uint16_t)sb[k + 1] & 0xFF) << 2;
+            val |= ((uint16_t)sb[k + 2] & 0x07) << 10;
+            break;
+        case 7:
+            val = sb[k + 0] >> 3;
+            val |= ((uint16_t)sb[k + 1] & 0xFF) << 5;
+            break;
+    }
+
+    return val;
+}
+#endif
+
+#if (PARAM_N1_BITSx2 == 15)
+/**
+ * @brief store a 15 bit value in a byte array at bit position i*15
+ *        must be called sequentially with increasing index
+ *
+ * @param sb  byte array pointer
+ * @param i   position in the byte array
+ * @param val 15 bit value to store
+ */
+static inline void store_15bit_in_bytearray(uint8_t* sb, int i, uint16_t val) {
+    val &= 0x7FFF;
+    int k = (i * 15) / 8;
+    switch (i % 8) {
+        case 0:
+            sb[k + 0] = val;
+            sb[k + 1] = val >> 8;
+            break;
+        case 1:
+            sb[k + 0] |= val << 7;
+            sb[k + 1] = val >> 1;
+            sb[k + 2] = val >> 9;
+            break;
+        case 2:
+            sb[k + 0] |= val << 6;
+            sb[k + 1] = val >> 2;
+            sb[k + 2] = val >> 10;
+            break;
+        case 3:
+            sb[k + 0] |= val << 5;
+            sb[k + 1] = val >> 3;
+            sb[k + 2] = val >> 11;
+            break;
+        case 4:
+            sb[k + 0] |= val << 4;
+            sb[k + 1] = val >> 4;
+            sb[k + 2] = val >> 12;
+            break;
+        case 5:
+            sb[k + 0] |= val << 3;
+            sb[k + 1] = val >> 5;
+            sb[k + 2] = val >> 13;
+            break;
+        case 6:
+            sb[k + 0] |= val << 2;
+            sb[k + 1] = val >> 6;
+            sb[k + 2] = val >> 14;
+            break;
+        case 7:
+            sb[k + 0] |= val << 1;
+            sb[k + 1] = val >> 7;
+            break;
+    }
+}
+
+/**
+ * @brief load a 15 bit value from a byte array at bit position i*15
+ *
+ * @param sb byte array pointer
+ * @param i  position in the byte array
+ * @return   uint16_t loaded value
+ */
+static inline uint16_t load_15bit_from_bytearray(const uint8_t* sb, int i) {
+    int k = (i * 15) / 8;
+    uint16_t val = 0;
+    switch (i % 8) {
+        case 0:
+            val = sb[k + 0];
+            val |= ((uint16_t)sb[k + 1] & 0x7F) << 8;
+            break;
+        case 1:
+            val = sb[k + 0] >> 7;
+            val |= ((uint16_t)sb[k + 1] & 0xFF) << 1;
+            val |= ((uint16_t)sb[k + 2] & 0x3F) << 9;
+            break;
+        case 2:
+            val = sb[k + 0] >> 6;
+            val |= ((uint16_t)sb[k + 1] & 0xFF) << 2;
+            val |= ((uint16_t)sb[k + 2] & 0x1F) << 10;
+            break;
+        case 3:
+            val = sb[k + 0] >> 5;
+            val |= ((uint16_t)sb[k + 1] & 0xFF) << 3;
+            val |= ((uint16_t)sb[k + 2] & 0x0F) << 11;
+            break;
+        case 4:
+            val = sb[k + 0] >> 4;
+            val |= ((uint16_t)sb[k + 1] & 0xFF) << 4;
+            val |= ((uint16_t)sb[k + 2] & 0x07) << 12;
+            break;
+        case 5:
+            val = sb[k + 0] >> 3;
+            val |= ((uint16_t)sb[k + 1] & 0xFF) << 5;
+            val |= ((uint16_t)sb[k + 2] & 0x03) << 13;
+            break;
+        case 6:
+            val = sb[k + 0] >> 2;
+            val |= ((uint16_t)sb[k + 1] & 0xFF) << 6;
+            val |= ((uint16_t)sb[k + 2] & 0x01) << 14;
+            break;
+        case 7:
+            val = sb[k + 0] >> 1;
+            val |= ((uint16_t)sb[k + 1] & 0xFF) << 7;
+            break;
+    }
+
+    return val;
+}
+#endif
+
+#if (PARAM_Q_BITS != 10)
+#error PARAM_Q bit size not supported
+#endif
+
+#if (PARAM_N1_BITSx2 == 13)
+static void store_2_perm_coeff_to_bytearray(uint8_t* sb, int i, uint16_t c0, uint16_t c1) {
+    store_13bit_in_bytearray(sb, i, (c1 * 90) + c0);
+}
+
+static void load_2_perm_coeff_from_bytearray(uint16_t* c0, uint16_t* c1, const uint8_t* sb, int i) {
+    uint16_t val = load_13bit_from_bytearray(sb, i);
+    *c0 = val % 90;
+    *c1 = val / 90;
+}
+#elif (PARAM_N1_BITSx2 == 14)
+static void store_2_perm_coeff_to_bytearray(uint8_t* sb, int i, uint16_t c0, uint16_t c1) {
+    store_7bit_in_bytearray(sb, i * 2 + 0, c0);
+    store_7bit_in_bytearray(sb, i * 2 + 1, c1);
+}
+
+static void load_2_perm_coeff_from_bytearray(uint16_t* c0, uint16_t* c1, const uint8_t* sb, int i) {
+    *c0 = load_7bit_from_bytearray(sb, i * 2 + 0);
+    *c1 = load_7bit_from_bytearray(sb, i * 2 + 1);
+}
+#elif (PARAM_N1_BITSx2 == 15)
+static void store_2_perm_coeff_to_bytearray(uint8_t* sb, int i, uint16_t c0, uint16_t c1) {
+    store_15bit_in_bytearray(sb, i, (c1 * 181) + c0);
+}
+
+static void load_2_perm_coeff_from_bytearray(uint16_t* c0, uint16_t* c1, const uint8_t* sb, int i) {
+    uint16_t val = load_15bit_from_bytearray(sb, i);
+    *c0 = val % 181;
+    *c1 = val / 181;
+}
+#else
+#error PARAM_N1 bit size not supported
+#endif
+
+void sig_perk_private_key_to_bytes(uint8_t sk_bytes[PRIVATE_KEY_BYTES], const perk_private_key_t* sk) {
+    memcpy(sk_bytes, sk->seed, SEED_BYTES);
+    memcpy(sk_bytes + SEED_BYTES, sk->pk_bytes, PUBLIC_KEY_BYTES);
+}
+
+void sig_perk_private_key_from_bytes(perk_private_key_t* sk, const uint8_t sk_bytes[PRIVATE_KEY_BYTES]) {
+    memcpy(sk->seed, sk_bytes, SEED_BYTES);
+    memcpy(sk->pk_bytes, sk_bytes + SEED_BYTES, PUBLIC_KEY_BYTES);
+    sig_perk_perm_set_random(sk->pi, sk->seed);
+}
+
+void sig_perk_public_key_to_bytes(uint8_t pk_bytes[PUBLIC_KEY_BYTES], const perk_public_key_t* pk) {
+    memcpy(pk_bytes, pk->seed, SEED_BYTES);
+    for (int i = 0; i < PARAM_M * PARAM_T; i++) {
+        store_10bit_in_bytearray(pk_bytes + SEED_BYTES, i, pk->y[i / PARAM_M][i % PARAM_M]);
+    }
+}
+
+int sig_perk_public_key_from_bytes(perk_public_key_t* pk, const uint8_t pk_bytes[PUBLIC_KEY_BYTES]) {
+    memcpy(pk->seed, pk_bytes, SEED_BYTES);
+    for (int i = 0; i < PARAM_M * PARAM_T; i++) {
+        uint16_t y = load_10bit_from_bytearray(pk_bytes + SEED_BYTES, i);
+        if (y >= PARAM_Q) {
+            // y out of range
+            return EXIT_FAILURE;
+        }
+        pk->y[i / PARAM_M][i % PARAM_M] = y;
+    }
+
+    // Generate H and x
+    sig_perk_mat_set_random(pk->H, pk->seed);
+    sig_perk_vect1_set_random_list(pk->x, pk->seed);
+
+    return EXIT_SUCCESS;
+}
+
+void sig_perk_challenges_from_bytes(challenge_t challenges[PARAM_TAU], const digest_t h1, const digest_t h2) {
+    sig_perk_prg_state_t h1_prg_state;
+    sig_perk_prg_state_t h2_prg_state;
+    uint16_t tmp_kappa;
+    uint16_t tmp_alpha;
+
+    // generate first challenge
+    sig_perk_prg_init(&h1_prg_state, PRG1, NULL, h1);
+    for (int i = 0; i < PARAM_TAU; ++i) {
+        uint16_t nonzero_check = 0;
+        do {
+            for (int j = 0; j < PARAM_T; ++j) {
+                do {
+                    sig_perk_prg(&h1_prg_state, (uint8_t*)&tmp_kappa, sizeof(tmp_kappa));
+                    tmp_kappa = tmp_kappa & PARAM_Q_MASK;
+                } while (tmp_kappa >= PARAM_Q);  // 0 <= tmp_kappa < PARAM_Q
+                challenges[i].kappa[j] = tmp_kappa;
+                nonzero_check |= tmp_kappa;
+            }
+        } while (!nonzero_check);
+    }
+    // generate second challenge
+    sig_perk_prg_init(&h2_prg_state, PRG1, NULL, h2);
+    for (int i = 0; i < PARAM_TAU; ++i) {
+        sig_perk_prg(&h2_prg_state, (uint8_t*)&tmp_alpha, sizeof(tmp_alpha));
+        tmp_alpha = (tmp_alpha & PARAM_N_MASK) + 1;  // 0 < tmp_alpha <= PARAM_N
+        challenges[i].alpha = tmp_alpha;
+    }
+}
+
+void sig_perk_signature_to_bytes(uint8_t sb[SIGNATURE_BYTES], const perk_signature_t* signature) {
+    memcpy(sb, signature->salt, sizeof(salt_t));
+    sb += sizeof(salt_t);
+    memcpy(sb, signature->h1, sizeof(digest_t));
+    sb += sizeof(digest_t);
+    memcpy(sb, signature->h2, sizeof(digest_t));
+    sb += sizeof(digest_t);
+
+    for (int i = 0; i < PARAM_TAU; i++) {
+        memcpy(sb, signature->responses[i].cmt_1_alpha, sizeof(cmt_t));
+        sb += sizeof(cmt_t);
+        memcpy(sb, signature->responses[i].z2_theta, sizeof(theta_t) * THETA_TREE_LEVELS);
+        sb += sizeof(theta_t) * THETA_TREE_LEVELS;
+    }
+
+    for (int i = 0; i < PARAM_TAU * PARAM_N1; i++) {
+        uint16_t z1 = signature->responses[i / PARAM_N1].z1[i % PARAM_N1];
+        store_10bit_in_bytearray(sb, i, z1);
+    }
+    sb += (PARAM_TAU * PARAM_N1 * PARAM_Q_BITS + 7) / 8;
+
+    for (int i = 0; i < ((PARAM_TAU * PARAM_N1) / 2); i++) {
+        uint16_t z2_pi0 = signature->responses[(i * 2 + 0) / PARAM_N1].z2_pi[(i * 2 + 0) % PARAM_N1];
+        uint16_t z2_pi1 = signature->responses[(i * 2 + 1) / PARAM_N1].z2_pi[(i * 2 + 1) % PARAM_N1];
+        store_2_perm_coeff_to_bytearray(sb, i, z2_pi0, z2_pi1);
+    }
+}
+
+/**
+ * @brief check the permutations to be valid:
+ *        - coefficients < PARAM_N1
+ *        - no coefficient duplicates
+ *
+ * @param responses perk_response_t array of size PARAM_TAU to be checked
+ * @return int != 0 if a not valid permutation is found
+ */
+static int permutations_not_valid(const perk_response_t responses[PARAM_TAU]) {
+    for (int i = 0; i < PARAM_TAU; i++) {
+        if (sig_perk_permutation_not_valid(responses[i].z2_pi)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+#define Z1_USED_BITS (uint8_t)((PARAM_TAU * PARAM_N1 * PARAM_Q_BITS + 7) % 8 + 1)
+static const uint8_t z1_unused_mask = (uint8_t)(((1U << (Z1_USED_BITS)) - 1) ^ 0xFFU);
+
+#define Z2_PI_USED_BITS (uint8_t)((PARAM_TAU * PARAM_N1 * PARAM_N1_BITSx2 / 2 + 7) % 8 + 1)
+static const uint8_t z2_p1_unused_mask = (uint8_t)(((1U << (Z2_PI_USED_BITS)) - 1) ^ 0xFFU);
+
+int sig_perk_signature_from_bytes(perk_signature_t* signature, const uint8_t sb[SIGNATURE_BYTES]) {
+    memcpy(signature->salt, sb, sizeof(salt_t));
+    sb += sizeof(salt_t);
+    memcpy(signature->h1, sb, sizeof(digest_t));
+    sb += sizeof(digest_t);
+    memcpy(signature->h2, sb, sizeof(digest_t));
+    sb += sizeof(digest_t);
+
+    for (int i = 0; i < PARAM_TAU; i++) {
+        memcpy(signature->responses[i].cmt_1_alpha, sb, sizeof(cmt_t));
+        sb += sizeof(cmt_t);
+        memcpy(signature->responses[i].z2_theta, sb, sizeof(theta_t) * THETA_TREE_LEVELS);
+        sb += sizeof(theta_t) * THETA_TREE_LEVELS;
+    }
+
+    for (int i = 0; i < PARAM_TAU * PARAM_N1; i++) {
+        uint16_t z1 = load_10bit_from_bytearray(sb, i);
+        if (z1 >= PARAM_Q) {
+            // z1 out of range
+            return EXIT_FAILURE;
+        }
+        signature->responses[i / PARAM_N1].z1[i % PARAM_N1] = z1;
+    }
+    sb += ((PARAM_TAU * PARAM_N1 * PARAM_Q_BITS + 7) / 8) - 1;
+
+    // cppcheck-suppress knownConditionTrueFalse
+    if (sb[0] & z1_unused_mask) {
+        // unused bits after the z1 != 0
+        return EXIT_FAILURE;
+    }
+
+    sb += 1;
+    for (int i = 0; i < ((PARAM_TAU * PARAM_N1) / 2); i++) {
+        uint16_t z2_pi0;
+        uint16_t z2_pi1;
+
+        load_2_perm_coeff_from_bytearray(&z2_pi0, &z2_pi1, sb, i);
+        signature->responses[(i * 2 + 0) / PARAM_N1].z2_pi[(i * 2 + 0) % PARAM_N1] = z2_pi0;
+        signature->responses[(i * 2 + 1) / PARAM_N1].z2_pi[(i * 2 + 1) % PARAM_N1] = z2_pi1;
+    }
+    sb += ((PARAM_TAU * PARAM_N1 * PARAM_N1_BITSx2 / 2 + 7) / 8) - 1;
+
+    if (sb[0] & z2_p1_unused_mask) {
+        // unused bits after the z2_pi != 0
+        return EXIT_FAILURE;
+    }
+
+    if (permutations_not_valid(signature->responses)) {
+        // loaded permutations are not valid
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/crypto_sign/perk-128-fast-3/ref/parsing.h
+++ b/crypto_sign/perk-128-fast-3/ref/parsing.h
@@ -1,0 +1,75 @@
+
+/**
+ * @file parsing.h
+ * @brief Header file for parsing.c
+ */
+
+#ifndef SIG_PERK_PARSING_H
+#define SIG_PERK_PARSING_H
+
+#include <stdint.h>
+#include "data_structures.h"
+#include "parameters.h"
+#include "signature.h"
+
+/**
+ * @brief Parse a private key into a string
+ *
+ * As technicality, the public key is appended to the private key in order to respect NIST API.
+ *
+ * @param [out] sk_bytes a string containing the private key
+ * @param [in] sk a pointer to private key structure
+ */
+void sig_perk_private_key_to_bytes(uint8_t sk_bytes[PRIVATE_KEY_BYTES], const perk_private_key_t* sk);
+
+/**
+ * @brief Parse a private key from a string
+ *
+ * @param [out] sk a pointer to private key structure
+ * @param [in] sk_bytes a string containing the private key
+ */
+void sig_perk_private_key_from_bytes(perk_private_key_t* sk, const uint8_t sk_bytes[PRIVATE_KEY_BYTES]);
+
+/**
+ * @brief Parse a public key into a string
+ *
+ * @param [out] pk_bytes a string containing the public key
+ * @param [in] pk a pointer to public key structure
+ */
+void sig_perk_public_key_to_bytes(uint8_t pk_bytes[PUBLIC_KEY_BYTES], const perk_public_key_t* pk);
+
+/**
+ * @brief Parse a public key from a string
+ *
+ * @param [out] pk a pointer to public key structure
+ * @param [in] pk_bytes a string containing the public key
+ */
+int sig_perk_public_key_from_bytes(perk_public_key_t* pk, const uint8_t pk_bytes[PUBLIC_KEY_BYTES]);
+
+/**
+ * @brief Generate challenges based on Fiat-Shamir transform
+ *
+ * @param [out] challenges an array containing the challenges for Pall the rounds
+ * @param [out] h1 a variable containing the digest h1
+ * @param [out] h2 a variable containing the digest h2
+ */
+void sig_perk_challenges_from_bytes(challenge_t challenges[PARAM_TAU], const digest_t h1, const digest_t h2);
+
+/**
+ * @brief Parse a signature into a string
+ *
+ * @param [out] sb a string containing the signature
+ * @param [in] signature a pointer to signature structure
+ */
+void sig_perk_signature_to_bytes(uint8_t sb[SIGNATURE_BYTES], const perk_signature_t* signature);
+
+/**
+ * @brief Parse a signature from a string
+ *
+ * @param [out] signature a pointer to signature structure
+ * @param [in] sb a string containing the signature
+ * @return int 0 if the parsing is successful and 1 otherwise
+ */
+int sig_perk_signature_from_bytes(perk_signature_t* signature, const uint8_t sb[SIGNATURE_BYTES]);
+
+#endif

--- a/crypto_sign/perk-128-fast-3/ref/permutation.c
+++ b/crypto_sign/perk-128-fast-3/ref/permutation.c
@@ -1,0 +1,100 @@
+
+/**
+ * @file permutation.c
+ * @brief Implementation of permutation related functions
+ */
+
+#include "permutation.h"
+#include <string.h>
+#include "crypto_memset.h"
+#include "djbsort.h"
+#include "symmetric.h"
+
+int sig_perk_perm_gen_given_random_input(perm_t p, const uint16_t rnd_buff[PARAM_N1]) {
+    uint32_t buffer[PARAM_N1];
+    // Use 16 bits for randomness
+    for (int i = 0; i < PARAM_N1; i++) {
+        buffer[i] = (((uint32_t)rnd_buff[i]) << 16) | i;
+    }
+    // sort
+    uint32_sort(buffer, PARAM_N1);
+    // check that no double random values were produced
+    for (int i = 1; i < PARAM_N1; i++) {
+        if ((buffer[i - 1] >> 16) == (buffer[i] >> 16)) {
+            return EXIT_FAILURE;
+        }
+    }
+    // extract permutation from buffer
+    for (int i = 0; i < PARAM_N1; i++) {
+        p[i] = (uint16_t)(buffer[i]);
+    }
+    return EXIT_SUCCESS;
+}
+
+void sig_perk_perm_set_random(perm_t p, const uint8_t seed[SEED_BYTES]) {
+    uint16_t rnd_buff[PARAM_N1];
+    sig_perk_prg_state_t prg;
+    sig_perk_prg_init(&prg, PRG1, NULL, seed);
+    sig_perk_prg(&prg, (uint8_t *)rnd_buff, sizeof(rnd_buff));
+
+    while (sig_perk_perm_gen_given_random_input(p, rnd_buff) != EXIT_SUCCESS) {
+        sig_perk_prg(&prg, (uint8_t *)rnd_buff, sizeof(rnd_buff));
+    }
+    memset(rnd_buff, 0, sizeof(rnd_buff));
+}
+
+void sig_perk_perm_vect_permute(vect1_t output, const perm_t p, const vect1_t input) {
+    uint32_t buffer[PARAM_N1];
+    for (int i = 0; i < PARAM_N1; ++i) {
+        buffer[i] = (((uint32_t)p[i]) << 16) | input[i];
+    }
+    uint32_sort(buffer, PARAM_N1);
+    for (int i = 0; i < PARAM_N1; ++i) {
+        output[i] = (uint16_t)(buffer[i]);
+    }
+}
+
+void sig_perk_perm_inverse(perm_t o, const perm_t p) {
+    uint32_t buffer[PARAM_N1];
+    for (int i = 0; i < PARAM_N1; i++) {
+        buffer[i] = (((uint32_t)p[i]) << 16) | i;
+    }
+    uint32_sort(buffer, PARAM_N1);
+
+    for (int i = 0; i < PARAM_N1; i++) {
+        o[i] = (uint16_t)(buffer[i]);
+    }
+}
+
+void sig_perk_perm_compose(perm_t o, const perm_t p1, const perm_t p2) {
+    uint32_t buffer[PARAM_N1];
+    perm_t tmp;
+    sig_perk_perm_inverse(tmp, p2);
+    for (int i = 0; i < PARAM_N1; ++i) {
+        buffer[i] = (((uint32_t)tmp[i]) << 16) | p1[i];
+    }
+    uint32_sort(buffer, PARAM_N1);
+    for (int i = 0; i < PARAM_N1; ++i) {
+        o[i] = (uint16_t)(buffer[i]);
+    }
+}
+
+// compute p1 compose p2^-1
+void sig_perk_perm_compose_inv(perm_t o, const perm_t p1, const perm_t p2) {
+    uint32_t buffer[PARAM_N1];
+    for (int i = 0; i < PARAM_N1; ++i) {
+        buffer[i] = (((uint32_t)p2[i]) << 16) | p1[i];
+    }
+    uint32_sort(buffer, PARAM_N1);
+    for (int i = 0; i < PARAM_N1; ++i) {
+        o[i] = (uint16_t)(buffer[i]);
+    }
+}
+
+void sig_perk_perm_gen_pi_1(perm_t *pi_i, const perm_t pi) {
+    sig_perk_perm_inverse(pi_i[0], pi_i[1]);
+    for (int i = 2; i < PARAM_N; i++) {
+        sig_perk_perm_compose_inv(pi_i[0], pi_i[0], pi_i[i]);
+    }
+    sig_perk_perm_compose(pi_i[0], pi_i[0], pi);
+}

--- a/crypto_sign/perk-128-fast-3/ref/permutation.h
+++ b/crypto_sign/perk-128-fast-3/ref/permutation.h
@@ -1,0 +1,123 @@
+
+/**
+ * @file permutation.h
+ * @brief header file for permutation.c
+ */
+
+#ifndef SIG_PERK_PERMUTATION_H
+#define SIG_PERK_PERMUTATION_H
+
+#include <stdint.h>
+#include "arithmetic.h"
+#include "parameters.h"
+
+/**
+ * @brief Permutation perm_t
+ *
+ * This structure contains an array of integers that is a permutation
+ */
+typedef uint8_t perm_t[PARAM_N1];
+
+/**
+ * @brief Set permutation to zero
+ *
+ * @param [out,in] input_perm a permutation
+ */
+void sig_perk_perm_set_zero(perm_t input_perm);
+
+/**
+ * @brief Generate a random permutation form a seed
+ *
+ * @param [out] p a permutation
+ * @param [in] seed a string containing a seed
+ */
+void sig_perk_perm_set_random(perm_t p, const uint8_t seed[SEED_BYTES]);
+
+/**
+ * @brief Generate a random permutation form random values
+ *
+ * @param [out] p a permutation
+ * @param [in] rnd_buff an array containing random values
+ */
+int sig_perk_perm_gen_given_random_input(perm_t p, const uint16_t rnd_buff[PARAM_N1]);
+
+/**
+ * @brief Apply a permutation on a vector
+ *
+ * @param [out] output a permuted vector
+ * @param [in] p a permutation
+ * @param [in] input a vector
+ */
+void sig_perk_perm_vect_permute(vect1_t output, const perm_t p, const vect1_t input);
+
+/**
+ * @brief Compute the composition on two permutations
+ *
+ * o = p1(p2)
+ *
+ * @param [out] o a permutation
+ * @param [in] p1 a permutation
+ * @param [in] p2 a permutation
+ */
+void sig_perk_perm_compose(perm_t o, const perm_t p1, const perm_t p2);
+
+/**
+ * @brief Compute the composition p1 compose p2^-1
+ *
+ * o = p1(p2)
+ *
+ * @param [out] o a permutation
+ * @param [in] p1 a permutation
+ * @param [in] p2 a permutation
+ */
+void sig_perk_perm_compose_inv(perm_t o, const perm_t p1, const perm_t p2);
+
+/**
+ * @brief Compute the inverse of a permutation
+ *
+ * o = p1^(-1)
+ *
+ * @param [out] o a permutation
+ * @param [in] p a permutation
+ */
+void sig_perk_perm_inverse(perm_t o, const perm_t p);
+
+/**
+ * @brief Compute the composition of given permutations
+ *
+ * @param [out] o a permutation
+ * @param [in] pi_i a pointer to permutations
+ * @param [in] nb_permutations an integer that is the number of permutations to be composed
+ */
+void sig_perk_perm_compose_set(perm_t o, perm_t *pi_i, const int nb_permutations);
+
+/**
+ * @brief Compute the permutation pi_1
+ *
+ * @param [out,in] pi_i a pointer to permutations
+ * @param [in] pi the secret permutation pi in the scheme
+ */
+void sig_perk_perm_gen_pi_1(perm_t *pi_i, const perm_t pi);
+
+/**
+ * @brief check the permutation to be valid:
+ *        - coefficients < PARAM_N1
+ *        - no coefficient duplicates
+ *
+ * @param p input permutation  to be checked
+ * @return int
+ */
+static inline int sig_perk_permutation_not_valid(const perm_t p) {
+    uint8_t c[sizeof(perm_t) / sizeof(**((perm_t *)0))] = {0};
+
+    for (unsigned i = 0; i < sizeof(c); i++) {
+        if (p[i] >= sizeof(c))
+            return 1;
+        if (c[p[i]])
+            return 1;
+        c[p[i]] = 1;
+    }
+    return 0;
+}
+
+#endif

--- a/crypto_sign/perk-128-fast-3/ref/sign.c
+++ b/crypto_sign/perk-128-fast-3/ref/sign.c
@@ -1,0 +1,121 @@
+
+/**
+ * @file sign.c
+ * @brief Implementation of the NIST api functions
+ */
+
+#include <stdlib.h>
+#include "api.h"
+#include "crypto_memset.h"
+#include "keygen.h"
+#include "parsing.h"
+#include "signature.h"
+#include "verbose.h"
+#include "verify.h"
+
+/**
+ * @brief Generate a keypair.
+ *
+ * @param [out] pk pointer to public key bytes
+ * @param [out] sk pointer to public key bytes
+ * @returns 0 if key generation is successful and -1 otherwise
+ */
+int crypto_sign_keypair(unsigned char *pk, unsigned char *sk) {
+    SIG_PERK_VERBOSE_PRINT_string("KEYGEN");
+    perk_public_key_t public_key = {0};
+    perk_private_key_t private_key = {0};
+
+    if (sig_perk_generate_keypair(&public_key, &private_key) != EXIT_SUCCESS) {
+        memset_zero(&private_key, sizeof(private_key));
+        return -1;
+    }
+
+    sig_perk_public_key_to_bytes(pk, &public_key);
+    sig_perk_private_key_to_bytes(sk, &private_key);
+
+    memset_zero(&private_key, sizeof(private_key));
+
+    SIG_PERK_VERBOSE_PRINT_uint8_t_array("pk", pk, PUBLIC_KEY_BYTES);
+    SIG_PERK_VERBOSE_PRINT_uint8_t_array("sk", sk, PRIVATE_KEY_BYTES);
+
+    return 0;
+}
+
+/**
+ * @brief Generate a signature of a message.
+ *
+ * @param [out] sm pointer to output signed message
+ *                 (allocated array with CRYPTO_BYTES + mlen bytes), can be equal to m
+ * @param [out] smlen pointer to output length of signed message
+ * @param [in] m pointer to message to be signed
+ * @param [in] mlen length of the message
+ * @param [in] sk pointer to the secret key bytes
+ * @returns 0 if signing is successful and -1 otherwise
+ */
+int crypto_sign(unsigned char *sm, size_t *smlen, const unsigned char *m, size_t mlen,
+                const unsigned char *sk) {
+    SIG_PERK_VERBOSE_PRINT_string("SIGN");
+    perk_private_key_t private_key = {0};
+    perk_signature_t signature = {0};
+    sig_perk_private_key_from_bytes(&private_key, sk);
+
+    for (size_t i = 0; i < mlen; ++i) sm[CRYPTO_BYTES + mlen - 1 - i] = m[mlen - 1 - i];
+
+    if (sig_perk_sign(&signature, &private_key, sm + CRYPTO_BYTES, (uint64_t)mlen) != EXIT_SUCCESS) {
+        memset_zero(&private_key, sizeof(private_key));
+        memset_zero(&signature, sizeof(signature));
+        return -1;
+    }
+
+    sig_perk_signature_to_bytes(sm, &signature);
+    memset_zero(&private_key, sizeof(private_key));
+
+    *smlen = mlen + CRYPTO_BYTES;
+
+    SIG_PERK_VERBOSE_PRINT_signature_raw(m, mlen, sm);
+
+    return 0;
+}
+
+/**
+ * @brief Verify a signed message
+ *
+ * @param [out] m pointer to output message
+ *                (allocated array with smlen bytes), can be equal to sm
+ * @param [out] mlen pointer to output length of message
+ * @param [in] sm pointer to signed message
+ * @param [in] smlen length of signed message
+ * @param [in] pk pointer to the public key bytes
+ * @returns 0 if signed message could be verified correctly and -1 otherwise
+ */
+int crypto_sign_open(unsigned char *m, size_t *mlen, const unsigned char *sm, size_t smlen,
+                     const unsigned char *pk) {
+    SIG_PERK_VERBOSE_PRINT_string("SIGN OPEN");
+    if (smlen < CRYPTO_BYTES)
+        goto badsig;
+
+    *mlen = smlen - CRYPTO_BYTES;
+
+    perk_signature_t signature;
+    challenge_t challenges[PARAM_TAU] = {0};
+
+    if (EXIT_SUCCESS != sig_perk_signature_from_bytes(&signature, sm)) {
+        goto badsig;
+    }
+
+    sig_perk_challenges_from_bytes(challenges, signature.h1, signature.h2);
+
+    // check the signature
+    if (EXIT_SUCCESS != sig_perk_verify(&signature, challenges, (uint8_t *)(sm + CRYPTO_BYTES), *mlen, (uint8_t *)pk)) {
+        goto badsig;
+    } else {
+        /* All good, copy msg, return 0 */
+        for (size_t i = 0; i < *mlen; ++i) m[i] = sm[CRYPTO_BYTES + i];
+        return 0;
+    }
+
+badsig:
+    /* Signature verification failed */
+    *mlen = -1;
+    return -1;
+}

--- a/crypto_sign/perk-128-fast-3/ref/signature.c
+++ b/crypto_sign/perk-128-fast-3/ref/signature.c
@@ -1,0 +1,177 @@
+
+/**
+ * @file signature.c
+ * @brief Implementation of sign function
+ */
+
+#include "signature.h"
+#include "parameters.h"
+
+#include <stdio.h>
+#include "common.h"
+#include "crypto_memset.h"
+#include "data_structures.h"
+#include "parsing.h"
+#include "randombytes.h"
+#include "symmetric.h"
+#include "theta_tree.h"
+#include "verbose.h"
+/**
+ * @brief Generate the commitments
+ *
+ * @param [out] signature a pointer to a signature structure
+ * @param [out,in] instances an array of PARAM_TAU instances
+ * @param [in] pi a variable that containing the permutation pi
+ * @param [in] H a variable containing the public matrix H
+ */
+static void sig_perk_gen_commitment(perk_signature_t *signature, perk_instance_t instances[PARAM_TAU], const perm_t pi,
+                                    const mat_t H) {
+    uint8_t rand_bytes[SEED_BYTES + SALT_BYTES] = {0};
+    sig_perk_prg_state_t prg_state;
+    vect1_t v = {0};
+    seed_t mseed = {0};
+
+    randombytes(rand_bytes, sizeof(rand_bytes));
+    memcpy(mseed, rand_bytes, SEED_BYTES);
+    memcpy(signature->salt, rand_bytes + SEED_BYTES, SALT_BYTES);
+    sig_perk_prg_init(&prg_state, PRG1, signature->salt, mseed);
+
+    SIG_PERK_VERBOSE_PRINT_uint8_t_array("mseed", mseed, SEED_BYTES);
+    SIG_PERK_VERBOSE_PRINT_uint8_t_array("salt", signature->salt, SALT_BYTES);
+
+    for (uint8_t i = 0; i < PARAM_TAU; ++i) {
+        theta_t *tree = instances[i].theta_tree;
+        sig_perk_prg(&prg_state, instances[i].theta_tree[0], sizeof(theta_t));
+        sig_perk_expand_theta_tree(signature->salt, tree);
+        sig_perk_gen_instance_commitments(&instances[i], signature->salt, i, pi);
+        sig_perk_gen_vect_v(v, instances[i].pi_i, instances[i].v_i, pi);
+        sig_perk_gen_instance_commitment_cmt_1(&instances[i], signature->salt, i, H, v);
+
+        SIG_PERK_VERBOSE_PRINT_theta_cmt_1_and_v(instances[i].theta_tree[0], instances[i].cmt_1, v, i + 1);
+    }
+}
+
+void sig_perk_gen_first_challenge(challenge_t challenge[PARAM_TAU], sig_perk_hash_state_t *saved_state, digest_t h1,
+                                  const salt_t salt, const uint8_t *m, const uint64_t mlen, const uint8_t *pk_bytes,
+                                  const perk_instance_t instances[PARAM_TAU]) {
+    sig_perk_hash_state_t hash_state;
+    sig_perk_prg_state_t prg_state;
+    uint16_t tmp_kappa;
+
+    sig_perk_hash_init(&hash_state, salt, NULL, NULL);
+    sig_perk_hash_update(&hash_state, m, mlen);
+    sig_perk_hash_update(&hash_state, pk_bytes, PUBLIC_KEY_BYTES);
+    memcpy(saved_state, &hash_state, sizeof(hash_state));
+    for (int i = 0; i < PARAM_TAU; ++i) {
+        sig_perk_hash_update(&hash_state, (uint8_t *)instances[i].cmt_1, sizeof(cmt_t));
+        sig_perk_hash_update(&hash_state, (uint8_t *)instances[i].cmt_1_i, sizeof(cmt_t) * PARAM_N);
+    }
+    sig_perk_hash_final(&hash_state, h1, H1);
+
+    sig_perk_prg_init(&prg_state, PRG1, NULL, h1);
+    for (int i = 0; i < PARAM_TAU; ++i) {
+        uint16_t nonzero_check = 0;
+        do {
+            for (int j = 0; j < PARAM_T; ++j) {
+                do {
+                    sig_perk_prg(&prg_state, (uint8_t *)&tmp_kappa, sizeof(tmp_kappa));
+                    tmp_kappa = tmp_kappa & PARAM_Q_MASK;
+                } while (tmp_kappa >= PARAM_Q);  // 0 <= tmp_kappa < PARAM_Q
+                challenge[i].kappa[j] = tmp_kappa;
+                nonzero_check |= tmp_kappa;
+            }
+        } while (!nonzero_check);
+    }
+}
+
+/**
+ * @brief Generate the first response
+ *
+ * @param [out] instances an array of PARAM_TAU instances
+ * @param [in] challenges an array of PARAM_TAU challenges
+ * @param [in] x an array of PARAM_T public values x_i
+ */
+static void sig_perk_gen_first_response(perk_instance_t instances[PARAM_TAU], const challenge_t challenges[PARAM_TAU],
+                                        const vect1_t x[PARAM_T]) {
+    for (int i = 0; i < PARAM_TAU; ++i) {
+        vect1_t tmp;
+        // compute s_0
+        sig_perk_vect1_mult_scalar_vect(instances[i].s_i[0], challenges[i].kappa[0], x[0]);
+        for (int j = 1; j < PARAM_T; j++) {
+            sig_perk_vect1_mult_scalar_vect(tmp, challenges[i].kappa[j], x[j]);
+            sig_perk_vect1_add(instances[i].s_i[0], instances[i].s_i[0], tmp);
+        }
+        for (int j = 0; j < PARAM_N; ++j) {
+            sig_perk_perm_vect_permute(tmp, instances[i].pi_i[j], instances[i].s_i[j]);
+            sig_perk_vect1_add(instances[i].s_i[j + 1], tmp, instances[i].v_i[j]);
+        }
+    }
+}
+
+void sig_perk_gen_second_challenge(digest_t h2, challenge_t challenge[PARAM_TAU], sig_perk_hash_state_t *saved_state,
+                                   const digest_t h1, perk_instance_t instances[PARAM_TAU]) {
+    sig_perk_prg_state_t prg_state;
+    uint16_t tmp_alpha;
+
+    sig_perk_hash_update(saved_state, h1, sizeof(digest_t));
+    for (int i = 0; i < PARAM_TAU; ++i) {
+        sig_perk_hash_update(saved_state, (uint8_t *)instances[i].s_i[1], sizeof(vect1_t) * PARAM_N);
+    }
+    sig_perk_hash_final(saved_state, h2, H2);
+
+    sig_perk_prg_init(&prg_state, PRG1, NULL, h2);
+    for (int i = 0; i < PARAM_TAU; ++i) {
+        sig_perk_prg(&prg_state, (uint8_t *)&tmp_alpha, sizeof(tmp_alpha));
+        tmp_alpha = (tmp_alpha & PARAM_N_MASK) + 1;  // 0 < tmp_alpha <= PARAM_N
+        challenge[i].alpha = tmp_alpha;
+    }
+}
+
+/**
+ * @brief Generate second response
+ *
+ * @param [out] signature a pointer to a signature structure
+ * @param [in] challenges an array of PARAM_TAU challenges
+ * @param [in] instances an array of PARAM_TAU instances
+ */
+static void sig_perk_gen_second_response(perk_signature_t *signature, const challenge_t challenges[PARAM_TAU],
+                                         const perk_instance_t instances[PARAM_TAU]) {
+    for (int i = 0; i < PARAM_TAU; ++i) {
+        const uint16_t alpha = challenges[i].alpha;
+        memcpy(signature->responses[i].z1, instances[i].s_i[alpha], sizeof(vect1_t));
+        if (alpha != 1) {
+            memcpy(signature->responses[i].z2_pi, instances[i].pi_i[0], sizeof(perm_t));
+        } else {
+            for (int j = 0; j < PARAM_N1; j++) {
+                signature->responses[i].z2_pi[j] = j;
+            }
+        }
+        sig_perk_get_theta_partial_tree_seeds(signature->responses[i].z2_theta, instances[i].theta_tree, alpha - 1);
+        memcpy(signature->responses[i].cmt_1_alpha, instances[i].cmt_1_i[alpha - 1], sizeof(cmt_t));
+    }
+}
+
+uint8_t sig_perk_sign(perk_signature_t *signature, const perk_private_key_t *sk, const uint8_t *message_bytes,
+                      const uint64_t message_length) {
+    perk_public_key_t pk;
+    perk_instance_t instances[PARAM_TAU] = {0};
+    challenge_t challenges[PARAM_TAU] = {0};
+    sig_perk_hash_state_t saved_state;  // stores a copy of the Keccak state ofter absorbing m, pk_bytes and com1
+
+    SIG_PERK_VERBOSE_PRINT_uint8_t_array("message m", message_bytes, message_length);
+
+    if (EXIT_SUCCESS != sig_perk_public_key_from_bytes(&pk, sk->pk_bytes)) {
+        return EXIT_FAILURE;
+    }
+    sig_perk_gen_commitment(signature, instances, sk->pi, (const vect1_t *)pk.H);
+    sig_perk_gen_first_challenge(challenges, &saved_state, signature->h1, signature->salt, message_bytes,
+                                 message_length, sk->pk_bytes, instances);
+    sig_perk_gen_first_response(instances, challenges, (const vect1_t *)pk.x);
+    sig_perk_gen_second_challenge(signature->h2, challenges, &saved_state, signature->h1, instances);
+    sig_perk_gen_second_response(signature, challenges, instances);
+
+    SIG_PERK_VERBOSE_PRINT_challenges(challenges);
+    SIG_PERK_VERBOSE_PRINT_signature(signature);
+
+    return EXIT_SUCCESS;
+}

--- a/crypto_sign/perk-128-fast-3/ref/signature.h
+++ b/crypto_sign/perk-128-fast-3/ref/signature.h
@@ -1,0 +1,64 @@
+
+/**
+ * @file signature.h
+ * @brief Header file for signature.c
+ */
+
+#ifndef SIG_PERK_SIGNATURE_H
+#define SIG_PERK_SIGNATURE_H
+
+#include <stdint.h>
+#include "data_structures.h"
+
+/** @struct challenge_t
+ *  @brief This structure contains the challenges of one round of the scheme
+ *  @var challenge_t::kappa
+ *  Member 'kappa' is an array of integers containing challenge kappa[i] with i in 0 .. PARAM_T - 1
+ *  @var challenge_t::alpha
+ *  Member 'alpha' is an integer containing challenge alpha
+ */
+typedef struct {
+    uint16_t kappa[PARAM_T];
+    uint16_t alpha;
+} challenge_t;
+
+/**
+ * @brief Generate challenges kappa for PARAM_TAU rounds
+ *
+ * @param [out] challenge an array of PARAM_TAU challenge_t struct
+ * @param [out,in] saved_state a pointer to Keccak state after absorbing salt, m and pk_bytes
+ * @param [out] h1 a variable containing the digest h1
+ * @param [in] salt a salt
+ * @param [in] m a pointer to message
+ * @param [in] mlen length of message
+ * @param [in] pk_bytes a pointer to the public key bytes
+ * @param [in] instances an array of PARAM_TAU instances
+ */
+void sig_perk_gen_first_challenge(challenge_t challenge[PARAM_TAU], sig_perk_hash_state_t *saved_state, digest_t h1,
+                                  const salt_t salt, const uint8_t *m, const uint64_t mlen, const uint8_t *pk_bytes,
+                                  const perk_instance_t instances[PARAM_TAU]);
+
+/**
+ * @brief Generate h2 and the challenges alpha for tau rounds
+ *
+ * @param [out] h2 a variable containing the digest h2
+ * @param [out] challenge an array of tau challenge_t struct
+ * @param [out,in] saved_state a pointer to Keccak state
+ * @param [out] h1 a variable containing the digest h1
+ * @param [in] instances an array of PARAM_TAU instances
+ */
+void sig_perk_gen_second_challenge(digest_t h2, challenge_t challenge[PARAM_TAU], sig_perk_hash_state_t *saved_state,
+                                   const digest_t h1, perk_instance_t instances[PARAM_TAU]);
+
+/**
+ * @brief Generate a signature
+ *
+ * @param [out] signature a pointer to signature structure
+ * @param [in] sk a pointer to private key structure
+ * @param [in] message_bytes a string containing a message
+ * @param [in] message_length an integer containing the length of the message
+ */
+uint8_t sig_perk_sign(perk_signature_t *signature, const perk_private_key_t *sk, const uint8_t *message_bytes,
+                      const uint64_t message_length);
+
+#endif

--- a/crypto_sign/perk-128-fast-3/ref/sort.c
+++ b/crypto_sign/perk-128-fast-3/ref/sort.c
@@ -1,0 +1,61 @@
+#include "djbsort.h"
+#define int32 int32_t
+
+#include "int32_minmax.inc"
+
+void int32_sort(int32 *x,long long n)
+{
+  long long top,p,q,r,i,j;
+
+  if (n < 2) return;
+  top = 1;
+  while (top < n - top) top += top;
+
+  for (p = top;p >= 1;p >>= 1) {
+    i = 0;
+    while (i + 2 * p <= n) {
+      for (j = i;j < i + p;++j)
+        int32_MINMAX(x[j],x[j+p]);
+      i += 2 * p;
+    }
+    for (j = i;j < n - p;++j)
+      int32_MINMAX(x[j],x[j+p]);
+
+    i = 0;
+    j = 0;
+    for (q = top;q > p;q >>= 1) {
+      if (j != i) for (;;) {
+        if (j == n - q) goto done;
+        int32 a = x[j + p];
+        for (r = q;r > p;r >>= 1)
+          int32_MINMAX(a,x[j + r]);
+        x[j + p] = a;
+        ++j;
+        if (j == i + p) {
+          i += 2 * p;
+          break;
+        }
+      }
+      while (i + p <= n - q) {
+        for (j = i;j < i + p;++j) {
+          int32 a = x[j + p];
+          for (r = q;r > p;r >>= 1)
+            int32_MINMAX(a,x[j+r]);
+          x[j + p] = a;
+        }
+        i += 2 * p;
+      }
+      /* now i + p > n - q */
+      j = i;
+      while (j < n - q) {
+        int32 a = x[j + p];
+        for (r = q;r > p;r >>= 1)
+          int32_MINMAX(a,x[j+r]);
+        x[j + p] = a;
+        ++j;
+      }
+
+      done: ;
+    }
+  }
+}

--- a/crypto_sign/perk-128-fast-3/ref/symmetric.c
+++ b/crypto_sign/perk-128-fast-3/ref/symmetric.c
@@ -1,0 +1,125 @@
+
+/**
+ * @file symmetric.c
+ * @brief Implementation of the symmetric functions
+ */
+
+#include "symmetric.h"
+#include "parameters.h"
+
+#if (SECURITY_BYTES == 16)
+#define shake_inc_init shake128_inc_init
+#define shake_inc_absorb shake128_inc_absorb
+#define shake_inc_finalize shake128_inc_finalize
+#define shake_inc_squeeze shake128_inc_squeeze
+
+#define sha3_inc_init sha3_256_inc_init
+#define sha3_inc_absorb sha3_256_inc_absorb
+#define sha3_inc_finalize sha3_256_inc_finalize
+#elif (SECURITY_BYTES == 24) 
+#define shake_inc_init shake256_inc_init
+#define shake_inc_absorb shake256_inc_absorb
+#define shake_inc_finalize shake256_inc_finalize
+#define shake_inc_squeeze shake256_inc_squeeze
+
+#define sha3_inc_init sha3_384_inc_init
+#define sha3_inc_absorb sha3_384_inc_absorb
+#define sha3_inc_finalize sha3_384_inc_finalize
+#elif (SECURITY_BYTES == 32)
+#define shake_inc_init shake256_inc_init
+#define shake_inc_absorb shake256_inc_absorb
+#define shake_inc_finalize shake256_inc_finalize
+#define shake_inc_squeeze shake256_inc_squeeze
+
+#define sha3_inc_init sha3_512_inc_init
+#define sha3_inc_absorb sha3_512_inc_absorb
+#define sha3_inc_finalize sha3_512_inc_finalize
+#endif
+
+void sig_perk_prg_init(sig_perk_prg_state_t *state, const uint8_t domain, const salt_t salt, const seed_t seed) {
+    #if 1 
+    shake_inc_init(state);
+    if(salt != NULL) {
+        shake_inc_absorb(state, salt, sizeof(salt_t));
+    }
+    if(seed != NULL) {
+        shake_inc_absorb(state, seed, sizeof(seed_t));
+    }
+    shake_inc_absorb(state, &domain, 1);
+    shake_inc_finalize(state);
+    #else
+    Keccak_HashInitialize_SHAKE(state);
+    if (salt != NULL) {
+        Keccak_HashUpdate(state, salt, sizeof(salt_t) * 8);
+    }
+    if (seed != NULL) {
+        Keccak_HashUpdate(state, seed, sizeof(seed_t) * 8);
+    }
+    Keccak_HashUpdate(state, &domain, 1 * 8);
+    Keccak_HashFinal(state, NULL);
+    #endif
+}
+
+void sig_perk_prg(sig_perk_prg_state_t *state, uint8_t *output, size_t outlen) {
+    #if 1
+    shake_inc_squeeze(output, outlen, state);
+    #else
+    Keccak_HashSqueeze(state, output, outlen * 8);
+    #endif
+}
+
+void sig_perk_hash_init(sig_perk_hash_state_t *state, const salt_t salt, const uint8_t *tau, const uint8_t *n) {
+    #if 1
+    sha3_inc_init(state);
+    sha3_inc_absorb(state, salt, sizeof(salt_t));
+    uint8_t counters[2];
+    int j = 0;
+    if (tau != NULL) {
+        counters[j] = *tau;
+        j++;
+    }
+    if (n != NULL) {
+        counters[j] = *n;
+        j++;
+    }
+    if (j != 0) {
+        sha3_inc_absorb(state, counters, j);
+    }
+
+    #else
+    Keccak_HashInitialize_SHA3(state);
+    Keccak_HashUpdate(state, salt, sizeof(salt_t) * 8);
+
+    uint8_t counters[2];
+    int j = 0;
+    if (tau != NULL) {
+        counters[j] = *tau;
+        j++;
+    }
+    if (n != NULL) {
+        counters[j] = *n;
+        j++;
+    }
+    if (j != 0) {
+        Keccak_HashUpdate(state, counters, j * 8);
+    }
+    #endif
+}
+
+void sig_perk_hash_update(sig_perk_hash_state_t *state, const uint8_t *message, const size_t message_size) {
+    #if 1 
+    sha3_inc_absorb(state, message, message_size);
+    #else
+    Keccak_HashUpdate(state, message, message_size * 8);
+    #endif
+}
+
+void sig_perk_hash_final(sig_perk_hash_state_t *state, digest_t digest, const uint8_t domain) {
+    #if 1
+    sha3_inc_absorb(state, &domain, 1);
+    sha3_inc_finalize(digest, state);
+    #else
+    Keccak_HashUpdate(state, &domain, 1 * 8);
+    Keccak_HashFinal(state, digest);
+    #endif
+}

--- a/crypto_sign/perk-128-fast-3/ref/symmetric.h
+++ b/crypto_sign/perk-128-fast-3/ref/symmetric.h
@@ -1,0 +1,108 @@
+
+/**
+ * @file symmetric.h
+ * @brief Header file for symmetric.c
+ */
+
+#ifndef SIG_PERK_SYMMETRIC_H
+#define SIG_PERK_SYMMETRIC_H
+
+#include <stdint.h>
+#include "fips202.h"
+#include "parameters.h"
+
+// domains for hash and prg
+#define H0   0x00
+#define H1   0x01
+#define H2   0x02
+#define H3   0x03
+#define PRG1 0x04
+#define PRG2 0x05
+
+/**
+ * @brief Salt salt_t
+ *
+ * This structure contains the salt
+ */
+typedef uint8_t salt_t[SALT_BYTES];
+
+/**
+ * @brief Digest digest_t
+ *
+ * This structure contains the digest
+ */
+typedef uint8_t digest_t[HASH_BYTES];
+
+/**
+ * @brief Seed seed_t
+ *
+ * This structure defines a string containing SEED_BYTES bytes
+ */
+typedef uint8_t seed_t[SEED_BYTES];
+
+#if (SECURITY_BYTES == 16)
+#define PRNG_BLOCK_SIZE 168  // SHAKE128 Block Size
+typedef shake128incctx sig_perk_prg_state_t;
+typedef sha3_256incctx sig_perk_hash_state_t;
+#elif (SECURITY_BYTES == 24)
+#define PRNG_BLOCK_SIZE 136  // SHAKE256 Block Size
+typedef shake256incctx sig_perk_prg_state_t;
+typedef sha3_384incctx sig_perk_hash_state_t;
+#elif (SECURITY_BYTES == 32)
+#define PRNG_BLOCK_SIZE 136  // SHAKE256 Block Size
+typedef shake256incctx sig_perk_prg_state_t;
+typedef sha3_512incctx sig_perk_hash_state_t;
+#endif
+
+
+
+/**
+ * @brief Initialize a PRNG
+ *        absorb the salt if not NULL and seed
+ *
+ * @param [out,in] state a pointer to the state of the PRNG
+ * @param [in] domain a byte that is the domain separator.
+ * @param [in] salt a string containing the salt. If Null no salt is absorbed.
+ * @param [in] seed a string containing the seed. If Null no seed is absorbed.
+ */
+void sig_perk_prg_init(sig_perk_prg_state_t *state, const uint8_t domain, const salt_t salt, const seed_t seed);
+
+/**
+ * @brief PRNG
+ *
+ * @param [out,in] state a pointer to the state of the PRNG
+ * @param [out] output pinter to the buffer to be filled
+ * @param [in] outlen size of the output
+ */
+void sig_perk_prg(sig_perk_prg_state_t *state, uint8_t *output, size_t outlen);
+
+/**
+ * @brief initialize the HASH function
+ *        absorb the salt and ctr if != 0
+ *
+ * @param [out,in] state a pointer to the state of the HASH.
+ * @param [in] salt a string containing the salt.
+ * @param [in] tau pointer to uint8_t absorbed after the salt. If NULL tau is not absorbed.
+ * @param [in] n pointer to uint8_t absorbed after the salt. If NULL n is not absorbed.
+ */
+void sig_perk_hash_init(sig_perk_hash_state_t *state, const salt_t salt, const uint8_t *tau, const uint8_t *n);
+
+/**
+ * @brief HASH update
+ *
+ * @param [out,in] state a pointer to the state of the HASH.
+ * @param [in] message message to be absorbed.
+ * @param [in] message_size size of the message.
+ */
+void sig_perk_hash_update(sig_perk_hash_state_t *state, const uint8_t *message, const size_t message_size);
+
+/**
+ * @brief output the digest for the chosen hash function (domain)
+ *
+ * @param [out,in] state a pointer to the state of the HASH.
+ * @param [out] digest output digest.
+ * @param [in] domain domain: H0, H1 or H2.
+ */
+void sig_perk_hash_final(sig_perk_hash_state_t *state, digest_t digest, const uint8_t domain);
+
+#endif

--- a/crypto_sign/perk-128-fast-3/ref/theta_tree.c
+++ b/crypto_sign/perk-128-fast-3/ref/theta_tree.c
@@ -1,0 +1,55 @@
+
+/**
+ * @file theta_tree.c
+ * @brief Implementation of tree related functions
+ */
+
+#include "theta_tree.h"
+#include "symmetric.h"
+#include <string.h>
+
+void sig_perk_expand_theta_tree(salt_t salt, perk_theta_seeds_tree_t theta_tree) {
+    sig_perk_hash_state_t state;
+
+    for (unsigned i = 0; i < (PARAM_N - 1); i++) {
+        unsigned from = i;
+        uint8_t idx = i;
+        unsigned to = i * 2 + 1;
+        sig_perk_hash_init(&state, salt, &idx, NULL);
+        sig_perk_hash_update(&state, theta_tree[from], sizeof(theta_t));
+        sig_perk_hash_final(&state, theta_tree[to], H3);
+    }
+}
+
+void sig_perk_expand_theta_partial_tree(salt_t salt, perk_theta_seeds_tree_t partial_theta_tree,
+                                        const theta_t partial_tree_seeds[THETA_TREE_LEVELS], const uint16_t alpha) {
+    sig_perk_hash_state_t state;
+    for (unsigned i = 0, l = 0, j = 0; i < (PARAM_N - 1); i++, j++) {
+        unsigned N = (1U << l);
+        if (j >= N) {  // increment level
+            l++;
+            j = 0;
+        }
+        unsigned from = i;
+        uint8_t idx = i;
+        unsigned to = i * 2 + 1;
+        unsigned missing = (alpha >> (THETA_TREE_LEVELS - l));            // missing node for the level l
+        unsigned is_right = (~alpha >> (THETA_TREE_LEVELS - 1 - l)) & 1;  // position in the level l + 1
+        if (j == missing) {
+            memcpy(partial_theta_tree[to + is_right], partial_tree_seeds[l], sizeof(theta_t));
+        } else {
+            sig_perk_hash_init(&state, salt, &idx, NULL);
+            sig_perk_hash_update(&state, partial_theta_tree[from], sizeof(theta_t));
+            sig_perk_hash_final(&state, partial_theta_tree[to], H3);
+        }
+    }
+}
+
+void sig_perk_get_theta_partial_tree_seeds(theta_t partial_tree_seeds[THETA_TREE_LEVELS],
+                                           const perk_theta_seeds_tree_t theta_tree, const uint16_t alpha) {
+    for (unsigned i = 0; i < THETA_TREE_LEVELS; i++) {
+        unsigned level = (1U << (i + 1U)) - 1;
+        unsigned node = (alpha >> (THETA_TREE_LEVELS - 1U - i)) ^ 1U;
+        memcpy(partial_tree_seeds[i], theta_tree[level + node], sizeof(theta_t));
+    }
+}

--- a/crypto_sign/perk-128-fast-3/ref/theta_tree.h
+++ b/crypto_sign/perk-128-fast-3/ref/theta_tree.h
@@ -1,0 +1,65 @@
+
+/**
+ * @file theta_tree.h
+ * @brief Header file for theta_tree.c
+ */
+
+#ifndef SIG_PERK_THETA_TREE_H
+#define SIG_PERK_THETA_TREE_H
+
+#include <stdint.h>
+#include "parameters.h"
+#include "symmetric.h"
+
+#define MASTER_THETA_SEED_OFFSET 0
+#define THETA_SEEDS_OFFSET       (PARAM_N - 1)
+
+/**
+ * @brief Theta theta_t
+ *
+ * This structure contains a seed of size SEED_BYTES bytes
+ */
+typedef uint8_t theta_t[SEED_BYTES];
+
+/**
+ * @brief An array of Theta
+ *
+ * This structure contains an array of 2 * PARAM_N - 1 theta_t
+ */
+typedef theta_t perk_theta_seeds_tree_t[2 * PARAM_N - 1];
+
+/**
+ * @brief expands the tree of thetas (nodes and leaves) from theta master seed and salt
+ *
+ * @param[in] salt
+ * @param[in,out] theta_tree a perk_theta_seeds_tree_t to be expanded with nodes and leaves
+ *                           theta_tree[0] is the master seed
+ *                           (theta_tree + THETA_SEEDS_OFFSET) is the array of theta_t
+ */
+void sig_perk_expand_theta_tree(salt_t salt, perk_theta_seeds_tree_t theta_tree);
+
+/**
+ * @brief expands the partial tree of thetas (nodes and leaves missing the alpha related ones)
+ *        from the array of THETA_TREE_LEVELS node seeds, salt and alpha
+ *
+ * @param[in] salt
+ * @param[out] partial_theta_tree a perk_theta_seeds_tree_t to be expanded with nodes and leaves
+ *                                from the array of partial_tree_seeds
+ * @param[in]  partial_tree_seeds array of seeds (one for each level)
+ * @param[in]  alpha              missing leaf
+ */
+void sig_perk_expand_theta_partial_tree(salt_t salt, perk_theta_seeds_tree_t partial_theta_tree,
+                                        const theta_t partial_tree_seeds[THETA_TREE_LEVELS], const uint16_t alpha);
+
+/**
+ * @brief returns the THETA_TREE_LEVELS seeds needed to compute all thetas but the alpha ones
+ *        given perk_theta_seeds_tree_t and alpha
+ *
+ * @param[out] partial_tree_seeds array of seeds needed to rebuild the tree with the missing alpha leaf
+ * @param[in]  theta_tree         a complete perk_theta_seeds_tree_t
+ * @param[in]  alpha              missing leaf
+ */
+void sig_perk_get_theta_partial_tree_seeds(theta_t partial_tree_seeds[THETA_TREE_LEVELS],
+                                           const perk_theta_seeds_tree_t theta_tree, const uint16_t alpha);
+
+#endif

--- a/crypto_sign/perk-128-fast-3/ref/verbose.c
+++ b/crypto_sign/perk-128-fast-3/ref/verbose.c
@@ -1,0 +1,131 @@
+
+/**
+ * @file verbose.c
+ * @brief Implementation of function for printing intermediate values (VERBOSE mode)
+ */
+
+#include "verbose.h"
+#include <stdio.h>
+#include "api.h"
+#include "parameters.h"
+
+void sig_perk_verbose_print_string(const char *var) {
+    printf("\n\n\n\n### %s ###", var);
+}
+
+void sig_perk_verbose_print_uint8_t_array(const char *var, const uint8_t *input, uint16_t size) {
+    printf("\n\n%s: ", var);
+    for (uint16_t i = 0; i < size; i++) {
+        printf("%02x", input[i]);
+    }
+}
+
+void sig_perk_verbose_print_uint16_t_array(const char *var, const uint16_t *input, uint16_t size) {
+    printf("\n\n%s: ", var);
+    for (uint16_t i = 0; i < size; i++) {
+        printf("%d ", input[i]);
+    }
+}
+
+void sig_perk_verbose_print_x(const vect1_t x[PARAM_T]) {
+    printf("\n\nx\n");
+    for (int i = 0; i < PARAM_T; ++i) {
+        printf(" x_%d: ", i + 1);
+        for (uint16_t j = 0; j < PARAM_N1; j++) {
+            printf("%03d ", x[i][j]);
+        }
+        printf("\n");
+    }
+}
+
+void sig_perk_verbose_print_y(const vect2_t y[PARAM_T]) {
+    printf("\n\ny\n");
+    for (int i = 0; i < PARAM_T; ++i) {
+        printf(" y_%d: ", i + 1);
+        for (uint16_t j = 0; j < PARAM_M; j++) {
+            printf("%03d ", y[i][j]);
+        }
+        printf("\n");
+    }
+}
+
+void sig_perk_verbose_print_matrix(const mat_t m_input) {
+    printf("\n\nH: \n");
+    for (int i = 0; i < PARAM_M; i++) {
+        printf("  ");
+        for (int j = 0; j < PARAM_N1; j++) {
+            printf("%03d ", m_input[i][j]);
+        }
+        printf("\n");
+    }
+}
+
+void sig_perk_verbose_print_theta_cmt_1_and_v(theta_t theta, cmt_t input, vect1_t v, uint16_t round_number) {
+    printf("\n\n Round %02d: ", round_number);
+    printf("\n  theta: ");
+    for (int i = 0; i < SEED_BYTES; ++i) {
+        printf("%02x", theta[i]);
+    }
+    printf("\n  cmt_1: ");
+    for (uint16_t i = 0; i < sizeof(cmt_t); i++) {
+        printf("%02x", ((uint8_t *)input)[i]);
+    }
+    printf("\n  v: ");
+    for (uint16_t i = 0; i < PARAM_N1; i++) {
+        printf("%d ", v[i]);
+    }
+}
+
+void sig_perk_verbose_print_challenges(challenge_t *challenges) {
+    printf("\n\nchallenges: ");
+    printf("\n\n kappa: ");
+    for (int i = 0; i < PARAM_TAU; i++) {
+        printf("\n  kappa_i (round %02d): ", i + 1);
+        for (int j = 0; j < PARAM_T; ++j) {
+            printf("%03d ", challenges[i].kappa[j]);
+        }
+    }
+    printf("\n\n alpha: ");
+    for (int i = 0; i < PARAM_TAU; i++) printf("%d ", challenges[i].alpha);
+}
+
+void sig_perk_verbose_print_signature(const perk_signature_t *signature) {
+    printf("\n\nsignature: ");
+    sig_perk_verbose_print_uint8_t_array(" h1", signature->h1, sizeof(digest_t));
+    sig_perk_verbose_print_uint8_t_array(" h2", signature->h2, sizeof(digest_t));
+    printf("\n\n responses");
+    for (int i = 0; i < PARAM_TAU; ++i) {
+        printf("\n\n  response round %d", i + 1);
+        sig_perk_verbose_print_uint16_t_array("   z1", signature->responses[i].z1, PARAM_N1);
+        sig_perk_verbose_print_uint8_t_array("   z2_pi", signature->responses[i].z2_pi, PARAM_N1);
+        printf("\n\n   z2_theta");
+        for (int j = 0; j < THETA_TREE_LEVELS; ++j) {
+            printf("\n    z2_theta seed # %d: ", j + 1);
+            for (int k = 0; k < SEED_BYTES; ++k) {
+                printf("%02x", signature->responses[i].z2_theta[j][k]);
+            }
+        }
+        sig_perk_verbose_print_uint8_t_array("  cmt_1_alpha", signature->responses[i].cmt_1_alpha, COMMITMENT_BYTES);
+    }
+}
+
+void sig_perk_verbose_print_signature_raw(const uint8_t *m, uint64_t mlen, const uint8_t *signature) {
+    sig_perk_verbose_print_uint8_t_array("m", m, mlen);
+    printf("\n\nsm(CRYPTO_BYTES):");
+    for (uint16_t i = 0; i < CRYPTO_BYTES; ++i) {
+        if (i % 32 == 0)
+            printf("\n");
+        printf("%02x", signature[i]);
+    }
+    printf("\n\n");
+}
+
+void sig_perk_verbose_print_thetas(perk_instance_t *instances) {
+    printf("\n\nthetas: ");
+    for (int i = 0; i < PARAM_TAU; ++i) {
+        printf("\n theta round %02d: ", i + 1);
+        for (int j = 0; j < SEED_BYTES; ++j) {
+            printf("%02x", instances[i].theta_tree[0][j]);
+        }
+    }
+}

--- a/crypto_sign/perk-128-fast-3/ref/verbose.h
+++ b/crypto_sign/perk-128-fast-3/ref/verbose.h
@@ -1,0 +1,129 @@
+
+/**
+ * @file verbose.h
+ * @brief Header file verbose.c
+ */
+
+#ifndef SIG_PERK_VERBOSE_H
+#define SIG_PERK_VERBOSE_H
+
+#include <stdint.h>
+#include "arithmetic.h"
+#include "data_structures.h"
+#include "signature.h"
+
+/**
+ * @brief Print a string
+ *
+ * @param [in] var a string containing the characters to print
+ */
+void sig_perk_verbose_print_string(const char *var);
+
+/**
+ * @brief Print in hexadecimal format a given number of bytes
+ *
+ * @param [in] var a string containing the name of the variable to be printed
+ * @param [in] input a string containing the data to be printed
+ * @param [in] size an integer that is the number of bytes to be printed
+ */
+void sig_perk_verbose_print_uint8_t_array(const char *var, const uint8_t *input, uint16_t size);
+
+/**
+ * @brief Print in decimal format a given number of bytes
+ *
+ * @param [in] var a string containing the name of the variable to be printed
+ * @param [in] input a string containing the data to be printed
+ * @param [in] size an integer that is the number of bytes to be printed
+ */
+void sig_perk_verbose_print_uint16_t_array(const char *var, const uint16_t *input, uint16_t size);
+
+/**
+ * @brief Print the public key x_i
+ *
+ * @param [in] x an array of vectors vect2_t x_i with i in 0 .. PARAM_T - 1
+ */
+void sig_perk_verbose_print_x(const vect1_t x[PARAM_T]);
+
+/**
+ * @brief Print the public key y_i
+ *
+ * @param [in] y an array of vectors vect2_t y_i with i in 0 .. PARAM_T - 1
+ */
+void sig_perk_verbose_print_y(const vect2_t y[PARAM_T]);
+
+/**
+ * @brief Print the values of the matrix H
+ *
+ * @param [in] m_input a matrix
+ */
+void sig_perk_verbose_print_matrix(const mat_t m_input);
+
+/**
+ * @brief Print the root randomness theta, commitment cmt_1 and vector v
+ *
+ * @param [in] theta a variable containing the seed theta
+ * @param [in] input a commitment
+ * @param [in] v a vector
+ * @param [in] round_number an integer containing the round number
+ */
+void sig_perk_verbose_print_theta_cmt_1_and_v(theta_t theta, cmt_t input, vect1_t v, uint16_t round_number);
+
+/**
+ * @brief Print the challenges
+ *
+ * @param [in] challenges a pointer to the challenges
+ */
+void sig_perk_verbose_print_challenges(challenge_t *challenges);
+
+/**
+ * @brief Print the signature
+ *
+ * @param [in] signature a pointer to the signature
+ */
+void sig_perk_verbose_print_signature(const perk_signature_t *signature);
+
+/**
+ * @brief Print the seeds thetas in all rounds
+ *
+ * @param [in] instances a pointer to the instances of the signature
+ */
+void sig_perk_verbose_print_thetas(perk_instance_t *instances);
+
+/**
+ * @brief Print a message and a signature
+ *
+ * @param [in] m a string containing a message
+ * @param [in] mlen an integer that is the size of a message
+ * @param [in] signature a string containing a signature
+ */
+void sig_perk_verbose_print_signature_raw(const uint8_t *m, uint64_t mlen, const uint8_t *signature);
+
+#ifdef VERBOSE
+#define SIG_PERK_VERBOSE_PRINT_string(var)                      sig_perk_verbose_print_string(var)
+#define SIG_PERK_VERBOSE_PRINT_uint8_t_array(var, input, size)  sig_perk_verbose_print_uint8_t_array(var, input, size)
+#define SIG_PERK_VERBOSE_PRINT_uint16_t_array(var, input, size) sig_perk_verbose_print_uint16_t_array(var, input, size)
+#define SIG_PERK_VERBOSE_PRINT_x(x)                             sig_perk_verbose_print_x(x)
+#define SIG_PERK_VERBOSE_PRINT_y(y)                             sig_perk_verbose_print_y(y)
+#define SIG_PERK_VERBOSE_PRINT_matrix(m_input)                  sig_perk_verbose_print_matrix(m_input)
+#define SIG_PERK_VERBOSE_PRINT_theta_cmt_1_and_v(theta, input, v, round_number) \
+    sig_perk_verbose_print_theta_cmt_1_and_v(theta, input, v, round_number)
+#define SIG_PERK_VERBOSE_PRINT_challenges(challenges) sig_perk_verbose_print_challenges(challenges)
+#define SIG_PERK_VERBOSE_PRINT_signature(signature)   sig_perk_verbose_print_signature(signature)
+#define SIG_PERK_VERBOSE_PRINT_thetas(instances)      sig_perk_verbose_print_thetas(instances)
+#define SIG_PERK_VERBOSE_PRINT_signature_raw(m, mlen, signature) \
+    sig_perk_verbose_print_signature_raw(m, mlen, signature)
+#else
+#define SIG_PERK_VERBOSE_PRINT_string(var)
+#define SIG_PERK_VERBOSE_PRINT_uint8_t_array(var, input, size)
+#define SIG_PERK_VERBOSE_PRINT_uint16_t_array(var, input, size)
+#define SIG_PERK_VERBOSE_PRINT_x(x)
+#define SIG_PERK_VERBOSE_PRINT_y(y)
+#define SIG_PERK_VERBOSE_PRINT_matrix(m_input)
+#define SIG_PERK_VERBOSE_PRINT_theta_cmt_1_and_v(theta, input, v, round_number)
+#define SIG_PERK_VERBOSE_PRINT_challenges(challenges)
+#define SIG_PERK_VERBOSE_PRINT_signature(signature)
+#define SIG_PERK_VERBOSE_PRINT_thetas(instances)
+#define SIG_PERK_VERBOSE_PRINT_signature_raw(m, mlen, signature)
+#endif
+
+#endif

--- a/crypto_sign/perk-128-fast-3/ref/verify.c
+++ b/crypto_sign/perk-128-fast-3/ref/verify.c
@@ -1,0 +1,192 @@
+
+/**
+ * @file verify.c
+ * @brief Implementation of verify function
+ */
+
+#include "verify.h"
+#include "common.h"
+#include "parsing.h"
+#include "string.h"
+
+/**
+ * @brief Compute the s_i in the verification step
+ *
+ * @param [out] s_i a pointer to the s_i
+ * @param [in] pi_i a pointer to the permutations pi_i
+ * @param [in] v_i a pointer to the vectors v_i
+ * @param [in] alpha an integer that is the challenge alpha
+ */
+static void sig_perk_verify_compute_s_i(vect1_t *s_i, perm_t *pi_i, vect1_t *v_i, const uint16_t alpha) {
+    vect1_t tmp;
+    for (int i = 0; i < PARAM_N; ++i) {
+        if ((i + 1) != alpha) {
+            // compute pi_i(s_i - 1)
+            for (int j = 0; j < PARAM_N1; ++j) {
+                tmp[pi_i[i][j]] = s_i[i][j];
+            }
+            sig_perk_vect1_add(s_i[i + 1], tmp, v_i[i]);
+        }
+    }
+}
+
+/**
+ * @brief Compute the commitments cmt_1_i for i in 1,...,N
+ *
+ * @param [out] instance a pointer to an instance
+ * @param [in] response a pointer to a response
+ * @param [in] challenge a variable containing the challenge
+ * @param [in] x an array containing x_i for i in 1,...,t
+ * @param [in] tau an integer that is an index in 0,...,tau
+ * @param [in] salt a variable containing the salt
+ */
+static void sig_perk_verify_gen_instance_commitments(perk_instance_t *instance, const perk_response_t *response,
+                                                     const challenge_t challenge, const vect1_t x[PARAM_T],
+                                                     const uint8_t tau, salt_t salt) {
+    vect1_t tmp;
+    // generate a partial tree with N-1 seeds
+    sig_perk_expand_theta_partial_tree(salt, instance->theta_tree, response->z2_theta, challenge.alpha - 1);
+
+    sig_perk_gen_pi_i_and_v_i(instance->pi_i, instance->v_i, salt, (const theta_t *)instance->theta_tree);
+    if (challenge.alpha != 1) {
+        memcpy(instance->pi_i[0], response->z2_pi, sizeof(perm_t));
+    }
+    //  compute s_0
+    sig_perk_vect1_mult_scalar_vect(instance->s_i[0], challenge.kappa[0], x[0]);
+    for (int i = 1; i < PARAM_T; i++) {
+        sig_perk_vect1_mult_scalar_vect(tmp, challenge.kappa[i], x[i]);
+        sig_perk_vect1_add(instance->s_i[0], instance->s_i[0], tmp);
+    }
+    // copy s_alpha
+    memcpy(instance->s_i[challenge.alpha], (uint8_t *)response->z1, sizeof(vect1_t));
+    sig_perk_verify_compute_s_i(instance->s_i, instance->pi_i, instance->v_i, challenge.alpha);
+    sig_perk_gen_commitment_cmt_1_i(instance, salt, tau);
+    // compute cmt_1,1
+    if (challenge.alpha != 1) {
+        uint8_t idx = 0;
+        sig_perk_hash_state_t state;
+        uint8_t pi_1_bytes[PARAM_N1];
+        for (int j = 0; j < PARAM_N1; ++j) {
+            pi_1_bytes[j] = (uint8_t)instance->pi_i[0][j];
+        }
+        sig_perk_hash_init(&state, salt, &tau, &idx);
+        sig_perk_hash_update(&state, pi_1_bytes, PARAM_N1);
+        sig_perk_hash_update(&state, instance->theta_tree[THETA_SEEDS_OFFSET], sizeof(theta_t));
+        sig_perk_hash_final(&state, instance->cmt_1_i[0], H0);
+    }
+    // copy cmt_1_alpha
+    memcpy(instance->cmt_1_i[challenge.alpha - 1], (uint8_t *)response->cmt_1_alpha, sizeof(cmt_t));
+}
+
+/**
+ * @brief Compute the commitment cmt_1
+ *
+ * @param [out] cmt_1 a variable that is the commitment
+ * @param [in] public_key a pointer to the public key
+ * @param [in] instance a pointer to an instance
+ * @param [in] kappa a variable containing the challenges kappa_i for i in 0,...,t
+ * @param [in] salt a variable containing the salt
+ * @param [in] tau an integer that is an index in 0,...,tau
+ */
+static void sig_perk_verify_gen_instance_commitment_cmt(cmt_t cmt_1, const perk_public_key_t *public_key,
+                                                        const perk_instance_t *instance, const uint16_t kappa[PARAM_T],
+                                                        const salt_t salt, const uint8_t tau) {
+    vect2_t tmp1, tmp2, tmp3;
+    sig_perk_hash_state_t state;
+
+    sig_perk_mat_vect_mul(tmp1, public_key->H, instance->s_i[PARAM_N]);
+    sig_perk_vect2_mult_scalar_vect(tmp2, kappa[0], public_key->y[0]);
+    for (int i = 1; i < PARAM_T; i++) {
+        sig_perk_vect2_mult_scalar_vect(tmp3, kappa[i], public_key->y[i]);
+        sig_perk_vect2_add(tmp2, tmp2, tmp3);
+    }
+    sig_perk_vect2_sub(tmp1, tmp1, tmp2);
+
+    sig_perk_hash_init(&state, salt, &tau, NULL);
+    sig_perk_hash_update(&state, (uint8_t *)tmp1, sizeof(tmp1));
+    sig_perk_hash_final(&state, cmt_1, H0);
+}
+
+/**
+ * @brief Compute the digest h1
+ *
+ * @param [out] h1 a variable containing the digest h1
+ * @param [out,in] saved_state pointer to Keccak state after absorbing salt, m and pk_bytes
+ * @param [in] salt a variable containing the salt
+ * @param [in] message_bytes a pointer to a string containing the message
+ * @param [in] message_length an integer that is the size of the message
+ * @param [in] pk_bytes a string containing the public key
+ * @param [in] instances an array containing tau instances
+ */
+static void sig_perk_verify_compute_h1(digest_t h1, sig_perk_hash_state_t *saved_state, const salt_t salt,
+                                       const uint8_t *message_bytes, const uint64_t message_length,
+                                       const uint8_t *pk_bytes, const perk_instance_t instances[PARAM_TAU]) {
+    sig_perk_hash_state_t hash_state;
+
+    sig_perk_hash_init(&hash_state, salt, NULL, NULL);
+    sig_perk_hash_update(&hash_state, message_bytes, message_length);
+    sig_perk_hash_update(&hash_state, pk_bytes, PUBLIC_KEY_BYTES);
+    memcpy(saved_state, &hash_state, sizeof(hash_state));
+    for (int i = 0; i < PARAM_TAU; ++i) {
+        sig_perk_hash_update(&hash_state, (uint8_t *)instances[i].cmt_1, sizeof(cmt_t));
+        sig_perk_hash_update(&hash_state, (uint8_t *)instances[i].cmt_1_i, sizeof(cmt_t) * PARAM_N);
+    }
+    sig_perk_hash_final(&hash_state, h1, H1);
+}
+
+/**
+ * @brief Compute the digest h2
+ *
+ * @param [out] h2 a variable containing the digest h2
+ * @param [out,in] saved_state pointer to Keccak state after absorbing salt, m and pk_bytes
+ * @param [in] h1 a variable containing the digest h1
+ * @param [in] instances an array containing tau instances
+ */
+static void sig_perk_verify_compute_h2(digest_t h2, sig_perk_hash_state_t *saved_state, const digest_t h1,
+                                       const perk_instance_t instances[PARAM_TAU]) {
+    sig_perk_hash_update(saved_state, h1, sizeof(digest_t));
+    for (int i = 0; i < PARAM_TAU; ++i) {
+        sig_perk_hash_update(saved_state, (uint8_t *)instances[i].s_i[1], sizeof(vect1_t) * PARAM_N);
+    }
+    sig_perk_hash_final(saved_state, h2, H2);
+}
+
+int sig_perk_verify(perk_signature_t *signature, const challenge_t challenge[PARAM_TAU], const uint8_t *message_bytes,
+                    const uint64_t message_length, const uint8_t *pk_bytes) {
+    perk_public_key_t public_key = {0};
+    perk_instance_t instances[PARAM_TAU] = {0};
+    digest_t h1_prime, h2_prime;
+    sig_perk_hash_state_t saved_state;
+
+    for (int i = 0; i < PARAM_TAU; ++i) {
+        if (challenge[i].alpha == 1) {
+            for (int j = 0; j < PARAM_N1; j++) {
+                if (signature->responses[i].z2_pi[j] != j) {
+                    return EXIT_FAILURE;
+                }
+            }
+        }
+    }
+    if (EXIT_SUCCESS != sig_perk_public_key_from_bytes(&public_key, pk_bytes)) {
+        return EXIT_FAILURE;
+    }
+    for (int i = 0; i < PARAM_TAU; ++i) {
+        sig_perk_verify_gen_instance_commitments(&instances[i], &signature->responses[i], challenge[i],
+                                                 (const vect1_t *)public_key.x, i, signature->salt);
+        sig_perk_verify_gen_instance_commitment_cmt(instances[i].cmt_1, &public_key, &instances[i], challenge[i].kappa,
+                                                    signature->salt, i);
+    }
+
+    sig_perk_verify_compute_h1(h1_prime, &saved_state, signature->salt, message_bytes, message_length, pk_bytes,
+                               instances);
+    sig_perk_verify_compute_h2(h2_prime, &saved_state, h1_prime, instances);
+
+    if (memcmp((uint8_t *)h1_prime, (uint8_t *)signature->h1, sizeof(digest_t))) {
+        return EXIT_FAILURE;
+    }
+    if (memcmp((uint8_t *)h2_prime, (uint8_t *)signature->h2, sizeof(digest_t))) {
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/crypto_sign/perk-128-fast-3/ref/verify.h
+++ b/crypto_sign/perk-128-fast-3/ref/verify.h
@@ -1,0 +1,26 @@
+
+/**
+ * @file verify.h
+ * @brief Header file for verify.c
+ */
+
+#ifndef SIG_PERK_VERIFY_H
+#define SIG_PERK_VERIFY_H
+
+#include "data_structures.h"
+#include "signature.h"
+
+/**
+ * @brief Verify a signature
+ *
+ * @param [out] signature a pointer to signature structure
+ * @param [in] challenge an array containing the challenges
+ * @param [in] message_bytes a pointer to a string containing the message
+ * @param [in] message_length an integer that is the size of the message
+ * @param [in] pk_bytes a string containing the public key
+ * @return int 0 if the verification is successful and 1 otherwise
+ */
+int sig_perk_verify(perk_signature_t *signature, const challenge_t challenge[PARAM_TAU], const uint8_t *message_bytes,
+                    const uint64_t message_length, const uint8_t *pk_bytes);
+
+#endif

--- a/crypto_sign/perk-128-fast-5/ref/api.h
+++ b/crypto_sign/perk-128-fast-5/ref/api.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/api.h

--- a/crypto_sign/perk-128-fast-5/ref/arithmetic.c
+++ b/crypto_sign/perk-128-fast-5/ref/arithmetic.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/arithmetic.c

--- a/crypto_sign/perk-128-fast-5/ref/arithmetic.h
+++ b/crypto_sign/perk-128-fast-5/ref/arithmetic.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/arithmetic.h

--- a/crypto_sign/perk-128-fast-5/ref/common.c
+++ b/crypto_sign/perk-128-fast-5/ref/common.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/common.c

--- a/crypto_sign/perk-128-fast-5/ref/common.h
+++ b/crypto_sign/perk-128-fast-5/ref/common.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/common.h

--- a/crypto_sign/perk-128-fast-5/ref/crypto_memset.c
+++ b/crypto_sign/perk-128-fast-5/ref/crypto_memset.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/crypto_memset.c

--- a/crypto_sign/perk-128-fast-5/ref/crypto_memset.h
+++ b/crypto_sign/perk-128-fast-5/ref/crypto_memset.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/crypto_memset.h

--- a/crypto_sign/perk-128-fast-5/ref/data_structures.h
+++ b/crypto_sign/perk-128-fast-5/ref/data_structures.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/data_structures.h

--- a/crypto_sign/perk-128-fast-5/ref/djbsort.c
+++ b/crypto_sign/perk-128-fast-5/ref/djbsort.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/djbsort.c

--- a/crypto_sign/perk-128-fast-5/ref/djbsort.h
+++ b/crypto_sign/perk-128-fast-5/ref/djbsort.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/djbsort.h

--- a/crypto_sign/perk-128-fast-5/ref/int32_minmax.inc
+++ b/crypto_sign/perk-128-fast-5/ref/int32_minmax.inc
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/int32_minmax.inc

--- a/crypto_sign/perk-128-fast-5/ref/keygen.c
+++ b/crypto_sign/perk-128-fast-5/ref/keygen.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/keygen.c

--- a/crypto_sign/perk-128-fast-5/ref/keygen.h
+++ b/crypto_sign/perk-128-fast-5/ref/keygen.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/keygen.h

--- a/crypto_sign/perk-128-fast-5/ref/parameters.h
+++ b/crypto_sign/perk-128-fast-5/ref/parameters.h
@@ -1,0 +1,43 @@
+
+/**
+ * @file parameters.h
+ * @brief Parameters of the PERK scheme
+ */
+
+#ifndef SIG_PERK_PARAMETER_H
+#define SIG_PERK_PARAMETER_H
+
+#define SECURITY_BYTES 16 /**< Number of bytes for the expected security level */
+#define PARAM_N1       83 /**< Parameter n of the scheme */
+#define PARAM_M        36 /**< Parameter m of the scheme */
+#define PARAM_T        5  /**< Parameter t of the scheme */
+#define PARAM_TAU      28 /**< Parameter tau of the scheme */
+
+#define PARAM_N           32 /**< Parameter N of the scheme */
+#define THETA_TREE_LEVELS 5  /**< The number of levels of the theta tree i.e log2(PARAM_N) */
+
+#define PARAM_Q      1021 /**< Parameter q of the scheme */
+#define PARAM_Q_BITS 10   /**< Number of bits needed to represent PARAM_Q */
+
+#define PARAM_N_MASK ((1U << THETA_TREE_LEVELS) - 1) /**< Mask for bits representing PARAM_N */
+#define PARAM_Q_MASK ((1U << PARAM_Q_BITS) - 1)      /**< Mask for bits representing PARAM_Q */
+
+#define PARAM_N1_BITSx2 13 /**< Bits needed to store two permutation coefficients */
+
+#define SEED_BYTES       SECURITY_BYTES       /**< Seed size used in the scheme */
+#define SALT_BYTES       (2 * SECURITY_BYTES) /**< Salt size used in the scheme */
+#define HASH_BYTES       (2 * SECURITY_BYTES) /**< Hash size used in the scheme */
+#define COMMITMENT_BYTES HASH_BYTES           /**< Commitment size used in the scheme */
+
+#define PUBLIC_KEY_BYTES  (SEED_BYTES + ((PARAM_M * PARAM_Q_BITS * PARAM_T + 7) / 8)) /**< Public key size */
+#define PRIVATE_KEY_BYTES (SEED_BYTES + PUBLIC_KEY_BYTES)                             /**< Private key size */
+
+#define SIGNATURE_BYTES                                                                                      \
+    (SALT_BYTES + (2 * COMMITMENT_BYTES) + (COMMITMENT_BYTES + SEED_BYTES * THETA_TREE_LEVELS) * PARAM_TAU + \
+     ((PARAM_TAU * PARAM_N1 * PARAM_Q_BITS + 7) / 8) +                                                       \
+     ((PARAM_TAU * PARAM_N1 * PARAM_N1_BITSx2 / 2 + 7) / 8)) /**< Signature size */
+
+#define EXIT_FAILURE 1 /**< Exit code in case of failure */
+#define EXIT_SUCCESS 0 /**< Exit code in case of success */
+
+#endif  // SIG_PERK_PARAMETER_H

--- a/crypto_sign/perk-128-fast-5/ref/parsing.c
+++ b/crypto_sign/perk-128-fast-5/ref/parsing.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/parsing.c

--- a/crypto_sign/perk-128-fast-5/ref/parsing.h
+++ b/crypto_sign/perk-128-fast-5/ref/parsing.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/parsing.h

--- a/crypto_sign/perk-128-fast-5/ref/permutation.c
+++ b/crypto_sign/perk-128-fast-5/ref/permutation.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/permutation.c

--- a/crypto_sign/perk-128-fast-5/ref/permutation.h
+++ b/crypto_sign/perk-128-fast-5/ref/permutation.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/permutation.h

--- a/crypto_sign/perk-128-fast-5/ref/sign.c
+++ b/crypto_sign/perk-128-fast-5/ref/sign.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/sign.c

--- a/crypto_sign/perk-128-fast-5/ref/signature.c
+++ b/crypto_sign/perk-128-fast-5/ref/signature.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/signature.c

--- a/crypto_sign/perk-128-fast-5/ref/signature.h
+++ b/crypto_sign/perk-128-fast-5/ref/signature.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/signature.h

--- a/crypto_sign/perk-128-fast-5/ref/sort.c
+++ b/crypto_sign/perk-128-fast-5/ref/sort.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/sort.c

--- a/crypto_sign/perk-128-fast-5/ref/symmetric.c
+++ b/crypto_sign/perk-128-fast-5/ref/symmetric.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/symmetric.c

--- a/crypto_sign/perk-128-fast-5/ref/symmetric.h
+++ b/crypto_sign/perk-128-fast-5/ref/symmetric.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/symmetric.h

--- a/crypto_sign/perk-128-fast-5/ref/theta_tree.c
+++ b/crypto_sign/perk-128-fast-5/ref/theta_tree.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/theta_tree.c

--- a/crypto_sign/perk-128-fast-5/ref/theta_tree.h
+++ b/crypto_sign/perk-128-fast-5/ref/theta_tree.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/theta_tree.h

--- a/crypto_sign/perk-128-fast-5/ref/verbose.c
+++ b/crypto_sign/perk-128-fast-5/ref/verbose.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verbose.c

--- a/crypto_sign/perk-128-fast-5/ref/verbose.h
+++ b/crypto_sign/perk-128-fast-5/ref/verbose.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verbose.h

--- a/crypto_sign/perk-128-fast-5/ref/verify.c
+++ b/crypto_sign/perk-128-fast-5/ref/verify.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verify.c

--- a/crypto_sign/perk-128-fast-5/ref/verify.h
+++ b/crypto_sign/perk-128-fast-5/ref/verify.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verify.h

--- a/crypto_sign/perk-128-short-3/ref/api.h
+++ b/crypto_sign/perk-128-short-3/ref/api.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/api.h

--- a/crypto_sign/perk-128-short-3/ref/arithmetic.c
+++ b/crypto_sign/perk-128-short-3/ref/arithmetic.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/arithmetic.c

--- a/crypto_sign/perk-128-short-3/ref/arithmetic.h
+++ b/crypto_sign/perk-128-short-3/ref/arithmetic.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/arithmetic.h

--- a/crypto_sign/perk-128-short-3/ref/common.c
+++ b/crypto_sign/perk-128-short-3/ref/common.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/common.c

--- a/crypto_sign/perk-128-short-3/ref/common.h
+++ b/crypto_sign/perk-128-short-3/ref/common.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/common.h

--- a/crypto_sign/perk-128-short-3/ref/crypto_memset.c
+++ b/crypto_sign/perk-128-short-3/ref/crypto_memset.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/crypto_memset.c

--- a/crypto_sign/perk-128-short-3/ref/crypto_memset.h
+++ b/crypto_sign/perk-128-short-3/ref/crypto_memset.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/crypto_memset.h

--- a/crypto_sign/perk-128-short-3/ref/data_structures.h
+++ b/crypto_sign/perk-128-short-3/ref/data_structures.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/data_structures.h

--- a/crypto_sign/perk-128-short-3/ref/djbsort.c
+++ b/crypto_sign/perk-128-short-3/ref/djbsort.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/djbsort.c

--- a/crypto_sign/perk-128-short-3/ref/djbsort.h
+++ b/crypto_sign/perk-128-short-3/ref/djbsort.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/djbsort.h

--- a/crypto_sign/perk-128-short-3/ref/int32_minmax.inc
+++ b/crypto_sign/perk-128-short-3/ref/int32_minmax.inc
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/int32_minmax.inc

--- a/crypto_sign/perk-128-short-3/ref/keygen.c
+++ b/crypto_sign/perk-128-short-3/ref/keygen.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/keygen.c

--- a/crypto_sign/perk-128-short-3/ref/keygen.h
+++ b/crypto_sign/perk-128-short-3/ref/keygen.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/keygen.h

--- a/crypto_sign/perk-128-short-3/ref/parameters.h
+++ b/crypto_sign/perk-128-short-3/ref/parameters.h
@@ -1,0 +1,43 @@
+
+/**
+ * @file parameters.h
+ * @brief Parameters of the PERK scheme
+ */
+
+#ifndef SIG_PERK_PARAMETER_H
+#define SIG_PERK_PARAMETER_H
+
+#define SECURITY_BYTES 16 /**< Number of bytes for the expected security level */
+#define PARAM_N1       79 /**< Parameter n of the scheme */
+#define PARAM_M        35 /**< Parameter m of the scheme */
+#define PARAM_T        3  /**< Parameter t of the scheme */
+#define PARAM_TAU      20 /**< Parameter tau of the scheme */
+
+#define PARAM_N           256 /**< Parameter N of the scheme */
+#define THETA_TREE_LEVELS 8   /**< The number of levels of the theta tree i.e log2(PARAM_N) */
+
+#define PARAM_Q      1021 /**< Parameter q of the scheme */
+#define PARAM_Q_BITS 10   /**< Number of bits needed to represent PARAM_Q */
+
+#define PARAM_N_MASK ((1U << THETA_TREE_LEVELS) - 1) /**< Mask for bits representing PARAM_N */
+#define PARAM_Q_MASK ((1U << PARAM_Q_BITS) - 1)      /**< Mask for bits representing PARAM_Q */
+
+#define PARAM_N1_BITSx2 13 /**< Bits needed to store two permutation coefficients */
+
+#define SEED_BYTES       SECURITY_BYTES       /**< Seed size used in the scheme */
+#define SALT_BYTES       (2 * SECURITY_BYTES) /**< Salt size used in the scheme */
+#define HASH_BYTES       (2 * SECURITY_BYTES) /**< Hash size used in the scheme */
+#define COMMITMENT_BYTES HASH_BYTES           /**< Commitment size used in the scheme */
+
+#define PUBLIC_KEY_BYTES  (SEED_BYTES + ((PARAM_M * PARAM_Q_BITS * PARAM_T + 7) / 8)) /**< Public key size */
+#define PRIVATE_KEY_BYTES (SEED_BYTES + PUBLIC_KEY_BYTES)                             /**< Private key size */
+
+#define SIGNATURE_BYTES                                                                                      \
+    (SALT_BYTES + (2 * COMMITMENT_BYTES) + (COMMITMENT_BYTES + SEED_BYTES * THETA_TREE_LEVELS) * PARAM_TAU + \
+     ((PARAM_TAU * PARAM_N1 * PARAM_Q_BITS + 7) / 8) +                                                       \
+     ((PARAM_TAU * PARAM_N1 * PARAM_N1_BITSx2 / 2 + 7) / 8)) /**< Signature size */
+
+#define EXIT_FAILURE 1 /**< Exit code in case of failure */
+#define EXIT_SUCCESS 0 /**< Exit code in case of success */
+
+#endif  // SIG_PERK_PARAMETER_H

--- a/crypto_sign/perk-128-short-3/ref/parsing.c
+++ b/crypto_sign/perk-128-short-3/ref/parsing.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/parsing.c

--- a/crypto_sign/perk-128-short-3/ref/parsing.h
+++ b/crypto_sign/perk-128-short-3/ref/parsing.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/parsing.h

--- a/crypto_sign/perk-128-short-3/ref/permutation.c
+++ b/crypto_sign/perk-128-short-3/ref/permutation.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/permutation.c

--- a/crypto_sign/perk-128-short-3/ref/permutation.h
+++ b/crypto_sign/perk-128-short-3/ref/permutation.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/permutation.h

--- a/crypto_sign/perk-128-short-3/ref/sign.c
+++ b/crypto_sign/perk-128-short-3/ref/sign.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/sign.c

--- a/crypto_sign/perk-128-short-3/ref/signature.c
+++ b/crypto_sign/perk-128-short-3/ref/signature.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/signature.c

--- a/crypto_sign/perk-128-short-3/ref/signature.h
+++ b/crypto_sign/perk-128-short-3/ref/signature.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/signature.h

--- a/crypto_sign/perk-128-short-3/ref/sort.c
+++ b/crypto_sign/perk-128-short-3/ref/sort.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/sort.c

--- a/crypto_sign/perk-128-short-3/ref/symmetric.c
+++ b/crypto_sign/perk-128-short-3/ref/symmetric.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/symmetric.c

--- a/crypto_sign/perk-128-short-3/ref/symmetric.h
+++ b/crypto_sign/perk-128-short-3/ref/symmetric.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/symmetric.h

--- a/crypto_sign/perk-128-short-3/ref/theta_tree.c
+++ b/crypto_sign/perk-128-short-3/ref/theta_tree.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/theta_tree.c

--- a/crypto_sign/perk-128-short-3/ref/theta_tree.h
+++ b/crypto_sign/perk-128-short-3/ref/theta_tree.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/theta_tree.h

--- a/crypto_sign/perk-128-short-3/ref/verbose.c
+++ b/crypto_sign/perk-128-short-3/ref/verbose.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verbose.c

--- a/crypto_sign/perk-128-short-3/ref/verbose.h
+++ b/crypto_sign/perk-128-short-3/ref/verbose.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verbose.h

--- a/crypto_sign/perk-128-short-3/ref/verify.c
+++ b/crypto_sign/perk-128-short-3/ref/verify.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verify.c

--- a/crypto_sign/perk-128-short-3/ref/verify.h
+++ b/crypto_sign/perk-128-short-3/ref/verify.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verify.h

--- a/crypto_sign/perk-128-short-5/ref/api.h
+++ b/crypto_sign/perk-128-short-5/ref/api.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/api.h

--- a/crypto_sign/perk-128-short-5/ref/arithmetic.c
+++ b/crypto_sign/perk-128-short-5/ref/arithmetic.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/arithmetic.c

--- a/crypto_sign/perk-128-short-5/ref/arithmetic.h
+++ b/crypto_sign/perk-128-short-5/ref/arithmetic.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/arithmetic.h

--- a/crypto_sign/perk-128-short-5/ref/common.c
+++ b/crypto_sign/perk-128-short-5/ref/common.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/common.c

--- a/crypto_sign/perk-128-short-5/ref/common.h
+++ b/crypto_sign/perk-128-short-5/ref/common.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/common.h

--- a/crypto_sign/perk-128-short-5/ref/crypto_memset.c
+++ b/crypto_sign/perk-128-short-5/ref/crypto_memset.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/crypto_memset.c

--- a/crypto_sign/perk-128-short-5/ref/crypto_memset.h
+++ b/crypto_sign/perk-128-short-5/ref/crypto_memset.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/crypto_memset.h

--- a/crypto_sign/perk-128-short-5/ref/data_structures.h
+++ b/crypto_sign/perk-128-short-5/ref/data_structures.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/data_structures.h

--- a/crypto_sign/perk-128-short-5/ref/djbsort.c
+++ b/crypto_sign/perk-128-short-5/ref/djbsort.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/djbsort.c

--- a/crypto_sign/perk-128-short-5/ref/djbsort.h
+++ b/crypto_sign/perk-128-short-5/ref/djbsort.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/djbsort.h

--- a/crypto_sign/perk-128-short-5/ref/int32_minmax.inc
+++ b/crypto_sign/perk-128-short-5/ref/int32_minmax.inc
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/int32_minmax.inc

--- a/crypto_sign/perk-128-short-5/ref/keygen.c
+++ b/crypto_sign/perk-128-short-5/ref/keygen.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/keygen.c

--- a/crypto_sign/perk-128-short-5/ref/keygen.h
+++ b/crypto_sign/perk-128-short-5/ref/keygen.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/keygen.h

--- a/crypto_sign/perk-128-short-5/ref/parameters.h
+++ b/crypto_sign/perk-128-short-5/ref/parameters.h
@@ -1,0 +1,43 @@
+
+/**
+ * @file parameters.h
+ * @brief Parameters of the PERK scheme
+ */
+
+#ifndef SIG_PERK_PARAMETER_H
+#define SIG_PERK_PARAMETER_H
+
+#define SECURITY_BYTES 16 /**< Number of bytes for the expected security level */
+#define PARAM_N1       83 /**< Parameter n of the scheme */
+#define PARAM_M        36 /**< Parameter m of the scheme */
+#define PARAM_T        5  /**< Parameter t of the scheme */
+#define PARAM_TAU      18 /**< Parameter tau of the scheme */
+
+#define PARAM_N           256 /**< Parameter N of the scheme */
+#define THETA_TREE_LEVELS 8   /**< The number of levels of the theta tree i.e log2(PARAM_N) */
+
+#define PARAM_Q      1021 /**< Parameter q of the scheme */
+#define PARAM_Q_BITS 10   /**< Number of bits needed to represent PARAM_Q */
+
+#define PARAM_N_MASK ((1U << THETA_TREE_LEVELS) - 1) /**< Mask for bits representing PARAM_N */
+#define PARAM_Q_MASK ((1U << PARAM_Q_BITS) - 1)      /**< Mask for bits representing PARAM_Q */
+
+#define PARAM_N1_BITSx2 13 /**< Bits needed to store two permutation coefficients */
+
+#define SEED_BYTES       SECURITY_BYTES       /**< Seed size used in the scheme */
+#define SALT_BYTES       (2 * SECURITY_BYTES) /**< Salt size used in the scheme */
+#define HASH_BYTES       (2 * SECURITY_BYTES) /**< Hash size used in the scheme */
+#define COMMITMENT_BYTES HASH_BYTES           /**< Commitment size used in the scheme */
+
+#define PUBLIC_KEY_BYTES  (SEED_BYTES + ((PARAM_M * PARAM_Q_BITS * PARAM_T + 7) / 8)) /**< Public key size */
+#define PRIVATE_KEY_BYTES (SEED_BYTES + PUBLIC_KEY_BYTES)                             /**< Private key size */
+
+#define SIGNATURE_BYTES                                                                                      \
+    (SALT_BYTES + (2 * COMMITMENT_BYTES) + (COMMITMENT_BYTES + SEED_BYTES * THETA_TREE_LEVELS) * PARAM_TAU + \
+     ((PARAM_TAU * PARAM_N1 * PARAM_Q_BITS + 7) / 8) +                                                       \
+     ((PARAM_TAU * PARAM_N1 * PARAM_N1_BITSx2 / 2 + 7) / 8)) /**< Signature size */
+
+#define EXIT_FAILURE 1 /**< Exit code in case of failure */
+#define EXIT_SUCCESS 0 /**< Exit code in case of success */
+
+#endif  // SIG_PERK_PARAMETER_H

--- a/crypto_sign/perk-128-short-5/ref/parsing.c
+++ b/crypto_sign/perk-128-short-5/ref/parsing.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/parsing.c

--- a/crypto_sign/perk-128-short-5/ref/parsing.h
+++ b/crypto_sign/perk-128-short-5/ref/parsing.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/parsing.h

--- a/crypto_sign/perk-128-short-5/ref/permutation.c
+++ b/crypto_sign/perk-128-short-5/ref/permutation.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/permutation.c

--- a/crypto_sign/perk-128-short-5/ref/permutation.h
+++ b/crypto_sign/perk-128-short-5/ref/permutation.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/permutation.h

--- a/crypto_sign/perk-128-short-5/ref/sign.c
+++ b/crypto_sign/perk-128-short-5/ref/sign.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/sign.c

--- a/crypto_sign/perk-128-short-5/ref/signature.c
+++ b/crypto_sign/perk-128-short-5/ref/signature.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/signature.c

--- a/crypto_sign/perk-128-short-5/ref/signature.h
+++ b/crypto_sign/perk-128-short-5/ref/signature.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/signature.h

--- a/crypto_sign/perk-128-short-5/ref/sort.c
+++ b/crypto_sign/perk-128-short-5/ref/sort.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/sort.c

--- a/crypto_sign/perk-128-short-5/ref/symmetric.c
+++ b/crypto_sign/perk-128-short-5/ref/symmetric.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/symmetric.c

--- a/crypto_sign/perk-128-short-5/ref/symmetric.h
+++ b/crypto_sign/perk-128-short-5/ref/symmetric.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/symmetric.h

--- a/crypto_sign/perk-128-short-5/ref/theta_tree.c
+++ b/crypto_sign/perk-128-short-5/ref/theta_tree.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/theta_tree.c

--- a/crypto_sign/perk-128-short-5/ref/theta_tree.h
+++ b/crypto_sign/perk-128-short-5/ref/theta_tree.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/theta_tree.h

--- a/crypto_sign/perk-128-short-5/ref/verbose.c
+++ b/crypto_sign/perk-128-short-5/ref/verbose.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verbose.c

--- a/crypto_sign/perk-128-short-5/ref/verbose.h
+++ b/crypto_sign/perk-128-short-5/ref/verbose.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verbose.h

--- a/crypto_sign/perk-128-short-5/ref/verify.c
+++ b/crypto_sign/perk-128-short-5/ref/verify.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verify.c

--- a/crypto_sign/perk-128-short-5/ref/verify.h
+++ b/crypto_sign/perk-128-short-5/ref/verify.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verify.h

--- a/crypto_sign/perk-192-fast-3/ref/api.h
+++ b/crypto_sign/perk-192-fast-3/ref/api.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/api.h

--- a/crypto_sign/perk-192-fast-3/ref/arithmetic.c
+++ b/crypto_sign/perk-192-fast-3/ref/arithmetic.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/arithmetic.c

--- a/crypto_sign/perk-192-fast-3/ref/arithmetic.h
+++ b/crypto_sign/perk-192-fast-3/ref/arithmetic.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/arithmetic.h

--- a/crypto_sign/perk-192-fast-3/ref/common.c
+++ b/crypto_sign/perk-192-fast-3/ref/common.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/common.c

--- a/crypto_sign/perk-192-fast-3/ref/common.h
+++ b/crypto_sign/perk-192-fast-3/ref/common.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/common.h

--- a/crypto_sign/perk-192-fast-3/ref/crypto_memset.c
+++ b/crypto_sign/perk-192-fast-3/ref/crypto_memset.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/crypto_memset.c

--- a/crypto_sign/perk-192-fast-3/ref/crypto_memset.h
+++ b/crypto_sign/perk-192-fast-3/ref/crypto_memset.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/crypto_memset.h

--- a/crypto_sign/perk-192-fast-3/ref/data_structures.h
+++ b/crypto_sign/perk-192-fast-3/ref/data_structures.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/data_structures.h

--- a/crypto_sign/perk-192-fast-3/ref/djbsort.c
+++ b/crypto_sign/perk-192-fast-3/ref/djbsort.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/djbsort.c

--- a/crypto_sign/perk-192-fast-3/ref/djbsort.h
+++ b/crypto_sign/perk-192-fast-3/ref/djbsort.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/djbsort.h

--- a/crypto_sign/perk-192-fast-3/ref/int32_minmax.inc
+++ b/crypto_sign/perk-192-fast-3/ref/int32_minmax.inc
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/int32_minmax.inc

--- a/crypto_sign/perk-192-fast-3/ref/keygen.c
+++ b/crypto_sign/perk-192-fast-3/ref/keygen.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/keygen.c

--- a/crypto_sign/perk-192-fast-3/ref/keygen.h
+++ b/crypto_sign/perk-192-fast-3/ref/keygen.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/keygen.h

--- a/crypto_sign/perk-192-fast-3/ref/parameters.h
+++ b/crypto_sign/perk-192-fast-3/ref/parameters.h
@@ -1,0 +1,43 @@
+
+/**
+ * @file parameters.h
+ * @brief Parameters of the PERK scheme
+ */
+
+#ifndef SIG_PERK_PARAMETER_H
+#define SIG_PERK_PARAMETER_H
+
+#define SECURITY_BYTES 24  /**< Number of bytes for the expected security level */
+#define PARAM_N1       112 /**< Parameter n of the scheme */
+#define PARAM_M        54  /**< Parameter m of the scheme */
+#define PARAM_T        3   /**< Parameter t of the scheme */
+#define PARAM_TAU      46  /**< Parameter tau of the scheme */
+
+#define PARAM_N           32 /**< Parameter N of the scheme */
+#define THETA_TREE_LEVELS 5  /**< The number of levels of the theta tree i.e log2(PARAM_N) */
+
+#define PARAM_Q      1021 /**< Parameter q of the scheme */
+#define PARAM_Q_BITS 10   /**< Number of bits needed to represent PARAM_Q */
+
+#define PARAM_N_MASK ((1U << THETA_TREE_LEVELS) - 1) /**< Mask for bits representing PARAM_N */
+#define PARAM_Q_MASK ((1U << PARAM_Q_BITS) - 1)      /**< Mask for bits representing PARAM_Q */
+
+#define PARAM_N1_BITSx2 14 /**< Bits needed to store two permutation coefficients */
+
+#define SEED_BYTES       SECURITY_BYTES       /**< Seed size used in the scheme */
+#define SALT_BYTES       (2 * SECURITY_BYTES) /**< Salt size used in the scheme */
+#define HASH_BYTES       (2 * SECURITY_BYTES) /**< Hash size used in the scheme */
+#define COMMITMENT_BYTES HASH_BYTES           /**< Commitment size used in the scheme */
+
+#define PUBLIC_KEY_BYTES  (SEED_BYTES + ((PARAM_M * PARAM_Q_BITS * PARAM_T + 7) / 8)) /**< Public key size */
+#define PRIVATE_KEY_BYTES (SEED_BYTES + PUBLIC_KEY_BYTES)                             /**< Private key size */
+
+#define SIGNATURE_BYTES                                                                                      \
+    (SALT_BYTES + (2 * COMMITMENT_BYTES) + (COMMITMENT_BYTES + SEED_BYTES * THETA_TREE_LEVELS) * PARAM_TAU + \
+     ((PARAM_TAU * PARAM_N1 * PARAM_Q_BITS + 7) / 8) +                                                       \
+     ((PARAM_TAU * PARAM_N1 * PARAM_N1_BITSx2 / 2 + 7) / 8)) /**< Signature size */
+
+#define EXIT_FAILURE 1 /**< Exit code in case of failure */
+#define EXIT_SUCCESS 0 /**< Exit code in case of success */
+
+#endif  // SIG_PERK_PARAMETER_H

--- a/crypto_sign/perk-192-fast-3/ref/parsing.c
+++ b/crypto_sign/perk-192-fast-3/ref/parsing.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/parsing.c

--- a/crypto_sign/perk-192-fast-3/ref/parsing.h
+++ b/crypto_sign/perk-192-fast-3/ref/parsing.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/parsing.h

--- a/crypto_sign/perk-192-fast-3/ref/permutation.c
+++ b/crypto_sign/perk-192-fast-3/ref/permutation.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/permutation.c

--- a/crypto_sign/perk-192-fast-3/ref/permutation.h
+++ b/crypto_sign/perk-192-fast-3/ref/permutation.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/permutation.h

--- a/crypto_sign/perk-192-fast-3/ref/sign.c
+++ b/crypto_sign/perk-192-fast-3/ref/sign.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/sign.c

--- a/crypto_sign/perk-192-fast-3/ref/signature.c
+++ b/crypto_sign/perk-192-fast-3/ref/signature.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/signature.c

--- a/crypto_sign/perk-192-fast-3/ref/signature.h
+++ b/crypto_sign/perk-192-fast-3/ref/signature.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/signature.h

--- a/crypto_sign/perk-192-fast-3/ref/sort.c
+++ b/crypto_sign/perk-192-fast-3/ref/sort.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/sort.c

--- a/crypto_sign/perk-192-fast-3/ref/symmetric.c
+++ b/crypto_sign/perk-192-fast-3/ref/symmetric.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/symmetric.c

--- a/crypto_sign/perk-192-fast-3/ref/symmetric.h
+++ b/crypto_sign/perk-192-fast-3/ref/symmetric.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/symmetric.h

--- a/crypto_sign/perk-192-fast-3/ref/theta_tree.c
+++ b/crypto_sign/perk-192-fast-3/ref/theta_tree.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/theta_tree.c

--- a/crypto_sign/perk-192-fast-3/ref/theta_tree.h
+++ b/crypto_sign/perk-192-fast-3/ref/theta_tree.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/theta_tree.h

--- a/crypto_sign/perk-192-fast-3/ref/verbose.c
+++ b/crypto_sign/perk-192-fast-3/ref/verbose.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verbose.c

--- a/crypto_sign/perk-192-fast-3/ref/verbose.h
+++ b/crypto_sign/perk-192-fast-3/ref/verbose.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verbose.h

--- a/crypto_sign/perk-192-fast-3/ref/verify.c
+++ b/crypto_sign/perk-192-fast-3/ref/verify.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verify.c

--- a/crypto_sign/perk-192-fast-3/ref/verify.h
+++ b/crypto_sign/perk-192-fast-3/ref/verify.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verify.h

--- a/crypto_sign/perk-192-fast-5/ref/api.h
+++ b/crypto_sign/perk-192-fast-5/ref/api.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/api.h

--- a/crypto_sign/perk-192-fast-5/ref/arithmetic.c
+++ b/crypto_sign/perk-192-fast-5/ref/arithmetic.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/arithmetic.c

--- a/crypto_sign/perk-192-fast-5/ref/arithmetic.h
+++ b/crypto_sign/perk-192-fast-5/ref/arithmetic.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/arithmetic.h

--- a/crypto_sign/perk-192-fast-5/ref/common.c
+++ b/crypto_sign/perk-192-fast-5/ref/common.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/common.c

--- a/crypto_sign/perk-192-fast-5/ref/common.h
+++ b/crypto_sign/perk-192-fast-5/ref/common.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/common.h

--- a/crypto_sign/perk-192-fast-5/ref/crypto_memset.c
+++ b/crypto_sign/perk-192-fast-5/ref/crypto_memset.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/crypto_memset.c

--- a/crypto_sign/perk-192-fast-5/ref/crypto_memset.h
+++ b/crypto_sign/perk-192-fast-5/ref/crypto_memset.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/crypto_memset.h

--- a/crypto_sign/perk-192-fast-5/ref/data_structures.h
+++ b/crypto_sign/perk-192-fast-5/ref/data_structures.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/data_structures.h

--- a/crypto_sign/perk-192-fast-5/ref/djbsort.c
+++ b/crypto_sign/perk-192-fast-5/ref/djbsort.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/djbsort.c

--- a/crypto_sign/perk-192-fast-5/ref/djbsort.h
+++ b/crypto_sign/perk-192-fast-5/ref/djbsort.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/djbsort.h

--- a/crypto_sign/perk-192-fast-5/ref/int32_minmax.inc
+++ b/crypto_sign/perk-192-fast-5/ref/int32_minmax.inc
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/int32_minmax.inc

--- a/crypto_sign/perk-192-fast-5/ref/keygen.c
+++ b/crypto_sign/perk-192-fast-5/ref/keygen.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/keygen.c

--- a/crypto_sign/perk-192-fast-5/ref/keygen.h
+++ b/crypto_sign/perk-192-fast-5/ref/keygen.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/keygen.h

--- a/crypto_sign/perk-192-fast-5/ref/parameters.h
+++ b/crypto_sign/perk-192-fast-5/ref/parameters.h
@@ -1,0 +1,43 @@
+
+/**
+ * @file parameters.h
+ * @brief Parameters of the PERK scheme
+ */
+
+#ifndef SIG_PERK_PARAMETER_H
+#define SIG_PERK_PARAMETER_H
+
+#define SECURITY_BYTES 24  /**< Number of bytes for the expected security level */
+#define PARAM_N1       116 /**< Parameter n of the scheme */
+#define PARAM_M        55  /**< Parameter m of the scheme */
+#define PARAM_T        5   /**< Parameter t of the scheme */
+#define PARAM_TAU      43  /**< Parameter tau of the scheme */
+
+#define PARAM_N           32 /**< Parameter N of the scheme */
+#define THETA_TREE_LEVELS 5  /**< The number of levels of the theta tree i.e log2(PARAM_N) */
+
+#define PARAM_Q      1021 /**< Parameter q of the scheme */
+#define PARAM_Q_BITS 10   /**< Number of bits needed to represent PARAM_Q */
+
+#define PARAM_N_MASK ((1U << THETA_TREE_LEVELS) - 1) /**< Mask for bits representing PARAM_N */
+#define PARAM_Q_MASK ((1U << PARAM_Q_BITS) - 1)      /**< Mask for bits representing PARAM_Q */
+
+#define PARAM_N1_BITSx2 14 /**< Bits needed to store two permutation coefficients */
+
+#define SEED_BYTES       SECURITY_BYTES       /**< Seed size used in the scheme */
+#define SALT_BYTES       (2 * SECURITY_BYTES) /**< Salt size used in the scheme */
+#define HASH_BYTES       (2 * SECURITY_BYTES) /**< Hash size used in the scheme */
+#define COMMITMENT_BYTES HASH_BYTES           /**< Commitment size used in the scheme */
+
+#define PUBLIC_KEY_BYTES  (SEED_BYTES + ((PARAM_M * PARAM_Q_BITS * PARAM_T + 7) / 8)) /**< Public key size */
+#define PRIVATE_KEY_BYTES (SEED_BYTES + PUBLIC_KEY_BYTES)                             /**< Private key size */
+
+#define SIGNATURE_BYTES                                                                                      \
+    (SALT_BYTES + (2 * COMMITMENT_BYTES) + (COMMITMENT_BYTES + SEED_BYTES * THETA_TREE_LEVELS) * PARAM_TAU + \
+     ((PARAM_TAU * PARAM_N1 * PARAM_Q_BITS + 7) / 8) +                                                       \
+     ((PARAM_TAU * PARAM_N1 * PARAM_N1_BITSx2 / 2 + 7) / 8)) /**< Signature size */
+
+#define EXIT_FAILURE 1 /**< Exit code in case of failure */
+#define EXIT_SUCCESS 0 /**< Exit code in case of success */
+
+#endif  // SIG_PERK_PARAMETER_H

--- a/crypto_sign/perk-192-fast-5/ref/parsing.c
+++ b/crypto_sign/perk-192-fast-5/ref/parsing.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/parsing.c

--- a/crypto_sign/perk-192-fast-5/ref/parsing.h
+++ b/crypto_sign/perk-192-fast-5/ref/parsing.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/parsing.h

--- a/crypto_sign/perk-192-fast-5/ref/permutation.c
+++ b/crypto_sign/perk-192-fast-5/ref/permutation.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/permutation.c

--- a/crypto_sign/perk-192-fast-5/ref/permutation.h
+++ b/crypto_sign/perk-192-fast-5/ref/permutation.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/permutation.h

--- a/crypto_sign/perk-192-fast-5/ref/sign.c
+++ b/crypto_sign/perk-192-fast-5/ref/sign.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/sign.c

--- a/crypto_sign/perk-192-fast-5/ref/signature.c
+++ b/crypto_sign/perk-192-fast-5/ref/signature.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/signature.c

--- a/crypto_sign/perk-192-fast-5/ref/signature.h
+++ b/crypto_sign/perk-192-fast-5/ref/signature.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/signature.h

--- a/crypto_sign/perk-192-fast-5/ref/sort.c
+++ b/crypto_sign/perk-192-fast-5/ref/sort.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/sort.c

--- a/crypto_sign/perk-192-fast-5/ref/symmetric.c
+++ b/crypto_sign/perk-192-fast-5/ref/symmetric.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/symmetric.c

--- a/crypto_sign/perk-192-fast-5/ref/symmetric.h
+++ b/crypto_sign/perk-192-fast-5/ref/symmetric.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/symmetric.h

--- a/crypto_sign/perk-192-fast-5/ref/theta_tree.c
+++ b/crypto_sign/perk-192-fast-5/ref/theta_tree.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/theta_tree.c

--- a/crypto_sign/perk-192-fast-5/ref/theta_tree.h
+++ b/crypto_sign/perk-192-fast-5/ref/theta_tree.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/theta_tree.h

--- a/crypto_sign/perk-192-fast-5/ref/verbose.c
+++ b/crypto_sign/perk-192-fast-5/ref/verbose.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verbose.c

--- a/crypto_sign/perk-192-fast-5/ref/verbose.h
+++ b/crypto_sign/perk-192-fast-5/ref/verbose.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verbose.h

--- a/crypto_sign/perk-192-fast-5/ref/verify.c
+++ b/crypto_sign/perk-192-fast-5/ref/verify.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verify.c

--- a/crypto_sign/perk-192-fast-5/ref/verify.h
+++ b/crypto_sign/perk-192-fast-5/ref/verify.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verify.h

--- a/crypto_sign/perk-256-fast-3/ref/api.h
+++ b/crypto_sign/perk-256-fast-3/ref/api.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/api.h

--- a/crypto_sign/perk-256-fast-3/ref/arithmetic.c
+++ b/crypto_sign/perk-256-fast-3/ref/arithmetic.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/arithmetic.c

--- a/crypto_sign/perk-256-fast-3/ref/arithmetic.h
+++ b/crypto_sign/perk-256-fast-3/ref/arithmetic.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/arithmetic.h

--- a/crypto_sign/perk-256-fast-3/ref/common.c
+++ b/crypto_sign/perk-256-fast-3/ref/common.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/common.c

--- a/crypto_sign/perk-256-fast-3/ref/common.h
+++ b/crypto_sign/perk-256-fast-3/ref/common.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/common.h

--- a/crypto_sign/perk-256-fast-3/ref/crypto_memset.c
+++ b/crypto_sign/perk-256-fast-3/ref/crypto_memset.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/crypto_memset.c

--- a/crypto_sign/perk-256-fast-3/ref/crypto_memset.h
+++ b/crypto_sign/perk-256-fast-3/ref/crypto_memset.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/crypto_memset.h

--- a/crypto_sign/perk-256-fast-3/ref/data_structures.h
+++ b/crypto_sign/perk-256-fast-3/ref/data_structures.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/data_structures.h

--- a/crypto_sign/perk-256-fast-3/ref/djbsort.c
+++ b/crypto_sign/perk-256-fast-3/ref/djbsort.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/djbsort.c

--- a/crypto_sign/perk-256-fast-3/ref/djbsort.h
+++ b/crypto_sign/perk-256-fast-3/ref/djbsort.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/djbsort.h

--- a/crypto_sign/perk-256-fast-3/ref/int32_minmax.inc
+++ b/crypto_sign/perk-256-fast-3/ref/int32_minmax.inc
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/int32_minmax.inc

--- a/crypto_sign/perk-256-fast-3/ref/keygen.c
+++ b/crypto_sign/perk-256-fast-3/ref/keygen.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/keygen.c

--- a/crypto_sign/perk-256-fast-3/ref/keygen.h
+++ b/crypto_sign/perk-256-fast-3/ref/keygen.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/keygen.h

--- a/crypto_sign/perk-256-fast-3/ref/parameters.h
+++ b/crypto_sign/perk-256-fast-3/ref/parameters.h
@@ -1,0 +1,43 @@
+
+/**
+ * @file parameters.h
+ * @brief Parameters of the PERK scheme
+ */
+
+#ifndef SIG_PERK_PARAMETER_H
+#define SIG_PERK_PARAMETER_H
+
+#define SECURITY_BYTES 32  /**< Number of bytes for the expected security level */
+#define PARAM_N1       146 /**< Parameter n of the scheme */
+#define PARAM_M        75  /**< Parameter m of the scheme */
+#define PARAM_T        3   /**< Parameter t of the scheme */
+#define PARAM_TAU      61  /**< Parameter tau of the scheme */
+
+#define PARAM_N           32 /**< Parameter N of the scheme */
+#define THETA_TREE_LEVELS 5  /**< The number of levels of the theta tree i.e log2(PARAM_N) */
+
+#define PARAM_Q      1021 /**< Parameter q of the scheme */
+#define PARAM_Q_BITS 10   /**< Number of bits needed to represent PARAM_Q */
+
+#define PARAM_N_MASK ((1U << THETA_TREE_LEVELS) - 1) /**< Mask for bits representing PARAM_N */
+#define PARAM_Q_MASK ((1U << PARAM_Q_BITS) - 1)      /**< Mask for bits representing PARAM_Q */
+
+#define PARAM_N1_BITSx2 15 /**< Bits needed to store two permutation coefficients */
+
+#define SEED_BYTES       SECURITY_BYTES       /**< Seed size used in the scheme */
+#define SALT_BYTES       (2 * SECURITY_BYTES) /**< Salt size used in the scheme */
+#define HASH_BYTES       (2 * SECURITY_BYTES) /**< Hash size used in the scheme */
+#define COMMITMENT_BYTES HASH_BYTES           /**< Commitment size used in the scheme */
+
+#define PUBLIC_KEY_BYTES  (SEED_BYTES + ((PARAM_M * PARAM_Q_BITS * PARAM_T + 7) / 8)) /**< Public key size */
+#define PRIVATE_KEY_BYTES (SEED_BYTES + PUBLIC_KEY_BYTES)                             /**< Private key size */
+
+#define SIGNATURE_BYTES                                                                                      \
+    (SALT_BYTES + (2 * COMMITMENT_BYTES) + (COMMITMENT_BYTES + SEED_BYTES * THETA_TREE_LEVELS) * PARAM_TAU + \
+     ((PARAM_TAU * PARAM_N1 * PARAM_Q_BITS + 7) / 8) +                                                       \
+     ((PARAM_TAU * PARAM_N1 * PARAM_N1_BITSx2 / 2 + 7) / 8)) /**< Signature size */
+
+#define EXIT_FAILURE 1 /**< Exit code in case of failure */
+#define EXIT_SUCCESS 0 /**< Exit code in case of success */
+
+#endif  // SIG_PERK_PARAMETER_H

--- a/crypto_sign/perk-256-fast-3/ref/parsing.c
+++ b/crypto_sign/perk-256-fast-3/ref/parsing.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/parsing.c

--- a/crypto_sign/perk-256-fast-3/ref/parsing.h
+++ b/crypto_sign/perk-256-fast-3/ref/parsing.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/parsing.h

--- a/crypto_sign/perk-256-fast-3/ref/permutation.c
+++ b/crypto_sign/perk-256-fast-3/ref/permutation.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/permutation.c

--- a/crypto_sign/perk-256-fast-3/ref/permutation.h
+++ b/crypto_sign/perk-256-fast-3/ref/permutation.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/permutation.h

--- a/crypto_sign/perk-256-fast-3/ref/sign.c
+++ b/crypto_sign/perk-256-fast-3/ref/sign.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/sign.c

--- a/crypto_sign/perk-256-fast-3/ref/signature.c
+++ b/crypto_sign/perk-256-fast-3/ref/signature.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/signature.c

--- a/crypto_sign/perk-256-fast-3/ref/signature.h
+++ b/crypto_sign/perk-256-fast-3/ref/signature.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/signature.h

--- a/crypto_sign/perk-256-fast-3/ref/sort.c
+++ b/crypto_sign/perk-256-fast-3/ref/sort.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/sort.c

--- a/crypto_sign/perk-256-fast-3/ref/symmetric.c
+++ b/crypto_sign/perk-256-fast-3/ref/symmetric.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/symmetric.c

--- a/crypto_sign/perk-256-fast-3/ref/symmetric.h
+++ b/crypto_sign/perk-256-fast-3/ref/symmetric.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/symmetric.h

--- a/crypto_sign/perk-256-fast-3/ref/theta_tree.c
+++ b/crypto_sign/perk-256-fast-3/ref/theta_tree.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/theta_tree.c

--- a/crypto_sign/perk-256-fast-3/ref/theta_tree.h
+++ b/crypto_sign/perk-256-fast-3/ref/theta_tree.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/theta_tree.h

--- a/crypto_sign/perk-256-fast-3/ref/verbose.c
+++ b/crypto_sign/perk-256-fast-3/ref/verbose.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verbose.c

--- a/crypto_sign/perk-256-fast-3/ref/verbose.h
+++ b/crypto_sign/perk-256-fast-3/ref/verbose.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verbose.h

--- a/crypto_sign/perk-256-fast-3/ref/verify.c
+++ b/crypto_sign/perk-256-fast-3/ref/verify.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verify.c

--- a/crypto_sign/perk-256-fast-3/ref/verify.h
+++ b/crypto_sign/perk-256-fast-3/ref/verify.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verify.h

--- a/crypto_sign/perk-256-fast-5/ref/api.h
+++ b/crypto_sign/perk-256-fast-5/ref/api.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/api.h

--- a/crypto_sign/perk-256-fast-5/ref/arithmetic.c
+++ b/crypto_sign/perk-256-fast-5/ref/arithmetic.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/arithmetic.c

--- a/crypto_sign/perk-256-fast-5/ref/arithmetic.h
+++ b/crypto_sign/perk-256-fast-5/ref/arithmetic.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/arithmetic.h

--- a/crypto_sign/perk-256-fast-5/ref/common.c
+++ b/crypto_sign/perk-256-fast-5/ref/common.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/common.c

--- a/crypto_sign/perk-256-fast-5/ref/common.h
+++ b/crypto_sign/perk-256-fast-5/ref/common.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/common.h

--- a/crypto_sign/perk-256-fast-5/ref/crypto_memset.c
+++ b/crypto_sign/perk-256-fast-5/ref/crypto_memset.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/crypto_memset.c

--- a/crypto_sign/perk-256-fast-5/ref/crypto_memset.h
+++ b/crypto_sign/perk-256-fast-5/ref/crypto_memset.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/crypto_memset.h

--- a/crypto_sign/perk-256-fast-5/ref/data_structures.h
+++ b/crypto_sign/perk-256-fast-5/ref/data_structures.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/data_structures.h

--- a/crypto_sign/perk-256-fast-5/ref/djbsort.c
+++ b/crypto_sign/perk-256-fast-5/ref/djbsort.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/djbsort.c

--- a/crypto_sign/perk-256-fast-5/ref/djbsort.h
+++ b/crypto_sign/perk-256-fast-5/ref/djbsort.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/djbsort.h

--- a/crypto_sign/perk-256-fast-5/ref/int32_minmax.inc
+++ b/crypto_sign/perk-256-fast-5/ref/int32_minmax.inc
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/int32_minmax.inc

--- a/crypto_sign/perk-256-fast-5/ref/keygen.c
+++ b/crypto_sign/perk-256-fast-5/ref/keygen.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/keygen.c

--- a/crypto_sign/perk-256-fast-5/ref/keygen.h
+++ b/crypto_sign/perk-256-fast-5/ref/keygen.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/keygen.h

--- a/crypto_sign/perk-256-fast-5/ref/parameters.h
+++ b/crypto_sign/perk-256-fast-5/ref/parameters.h
@@ -1,0 +1,43 @@
+
+/**
+ * @file parameters.h
+ * @brief Parameters of the PERK scheme
+ */
+
+#ifndef SIG_PERK_PARAMETER_H
+#define SIG_PERK_PARAMETER_H
+
+#define SECURITY_BYTES 32  /**< Number of bytes for the expected security level */
+#define PARAM_N1       150 /**< Parameter n of the scheme */
+#define PARAM_M        76  /**< Parameter m of the scheme */
+#define PARAM_T        5   /**< Parameter t of the scheme */
+#define PARAM_TAU      57  /**< Parameter tau of the scheme */
+
+#define PARAM_N           32 /**< Parameter N of the scheme */
+#define THETA_TREE_LEVELS 5  /**< The number of levels of the theta tree i.e log2(PARAM_N) */
+
+#define PARAM_Q      1021 /**< Parameter q of the scheme */
+#define PARAM_Q_BITS 10   /**< Number of bits needed to represent PARAM_Q */
+
+#define PARAM_N_MASK ((1U << THETA_TREE_LEVELS) - 1) /**< Mask for bits representing PARAM_N */
+#define PARAM_Q_MASK ((1U << PARAM_Q_BITS) - 1)      /**< Mask for bits representing PARAM_Q */
+
+#define PARAM_N1_BITSx2 15 /**< Bits needed to store two permutation coefficients */
+
+#define SEED_BYTES       SECURITY_BYTES       /**< Seed size used in the scheme */
+#define SALT_BYTES       (2 * SECURITY_BYTES) /**< Salt size used in the scheme */
+#define HASH_BYTES       (2 * SECURITY_BYTES) /**< Hash size used in the scheme */
+#define COMMITMENT_BYTES HASH_BYTES           /**< Commitment size used in the scheme */
+
+#define PUBLIC_KEY_BYTES  (SEED_BYTES + ((PARAM_M * PARAM_Q_BITS * PARAM_T + 7) / 8)) /**< Public key size */
+#define PRIVATE_KEY_BYTES (SEED_BYTES + PUBLIC_KEY_BYTES)                             /**< Private key size */
+
+#define SIGNATURE_BYTES                                                                                      \
+    (SALT_BYTES + (2 * COMMITMENT_BYTES) + (COMMITMENT_BYTES + SEED_BYTES * THETA_TREE_LEVELS) * PARAM_TAU + \
+     ((PARAM_TAU * PARAM_N1 * PARAM_Q_BITS + 7) / 8) +                                                       \
+     ((PARAM_TAU * PARAM_N1 * PARAM_N1_BITSx2 / 2 + 7) / 8)) /**< Signature size */
+
+#define EXIT_FAILURE 1 /**< Exit code in case of failure */
+#define EXIT_SUCCESS 0 /**< Exit code in case of success */
+
+#endif  // SIG_PERK_PARAMETER_H

--- a/crypto_sign/perk-256-fast-5/ref/parsing.c
+++ b/crypto_sign/perk-256-fast-5/ref/parsing.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/parsing.c

--- a/crypto_sign/perk-256-fast-5/ref/parsing.h
+++ b/crypto_sign/perk-256-fast-5/ref/parsing.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/parsing.h

--- a/crypto_sign/perk-256-fast-5/ref/permutation.c
+++ b/crypto_sign/perk-256-fast-5/ref/permutation.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/permutation.c

--- a/crypto_sign/perk-256-fast-5/ref/permutation.h
+++ b/crypto_sign/perk-256-fast-5/ref/permutation.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/permutation.h

--- a/crypto_sign/perk-256-fast-5/ref/sign.c
+++ b/crypto_sign/perk-256-fast-5/ref/sign.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/sign.c

--- a/crypto_sign/perk-256-fast-5/ref/signature.c
+++ b/crypto_sign/perk-256-fast-5/ref/signature.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/signature.c

--- a/crypto_sign/perk-256-fast-5/ref/signature.h
+++ b/crypto_sign/perk-256-fast-5/ref/signature.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/signature.h

--- a/crypto_sign/perk-256-fast-5/ref/sort.c
+++ b/crypto_sign/perk-256-fast-5/ref/sort.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/sort.c

--- a/crypto_sign/perk-256-fast-5/ref/symmetric.c
+++ b/crypto_sign/perk-256-fast-5/ref/symmetric.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/symmetric.c

--- a/crypto_sign/perk-256-fast-5/ref/symmetric.h
+++ b/crypto_sign/perk-256-fast-5/ref/symmetric.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/symmetric.h

--- a/crypto_sign/perk-256-fast-5/ref/theta_tree.c
+++ b/crypto_sign/perk-256-fast-5/ref/theta_tree.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/theta_tree.c

--- a/crypto_sign/perk-256-fast-5/ref/theta_tree.h
+++ b/crypto_sign/perk-256-fast-5/ref/theta_tree.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/theta_tree.h

--- a/crypto_sign/perk-256-fast-5/ref/verbose.c
+++ b/crypto_sign/perk-256-fast-5/ref/verbose.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verbose.c

--- a/crypto_sign/perk-256-fast-5/ref/verbose.h
+++ b/crypto_sign/perk-256-fast-5/ref/verbose.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verbose.h

--- a/crypto_sign/perk-256-fast-5/ref/verify.c
+++ b/crypto_sign/perk-256-fast-5/ref/verify.c
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verify.c

--- a/crypto_sign/perk-256-fast-5/ref/verify.h
+++ b/crypto_sign/perk-256-fast-5/ref/verify.h
@@ -1,0 +1,1 @@
+../../perk-128-fast-3/ref/verify.h


### PR DESCRIPTION
https://github.com/mupq/pqm4/issues/284

This adds the implementations from https://pqc-perk.org/assets/downloads/perk_2023_05_31.zip. 

perk-128-fast-{3,5} should be able to run on the 640 KB RAM board. The perk-{192,256}-short-* are out of reach even with 4 MB RAM in qemu, so I did not include those.
The remaining ones run in 4 MB RAM, but won't run on the board.

I have tested that testvectors, tests, benchmarks run fine on qemu and the nucleo-l476rg.

There is a newer package available at https://pqc-perk.org/assets/downloads/perk_2023_10_16.zip (with a change in testvectors), but that one relies on GMP....