### PR TITLE
Progressbar for the console

### DIFF
--- a/crypto_kem/test.c
+++ b/crypto_kem/test.c
@@ -90,8 +90,8 @@ static int test_keys(void)
     {
       hal_send_str("OK KEYS\n");
     }
+    hal_send_str("+");
   }
-
   return 0;
 }
 
@@ -126,6 +126,7 @@ static int test_invalid_sk_a(void)
     {
       hal_send_str("OK invalid sk_a\n");
     }
+    hal_send_str("+");
   }
 
   return 0;
@@ -165,6 +166,7 @@ static int test_invalid_ciphertext(void)
     {
       hal_send_str("OK invalid ciphertext\n");
     }
+    hal_send_str("+");
   }
 
   return 0;

--- a/crypto_sign/test.c
+++ b/crypto_sign/test.c
@@ -89,6 +89,7 @@ static int test_sign(void)
             hal_send_str("OK Signature did verify correctly!\n");
         }
         hal_send_str("crypto_sign_open DONE.\n");
+        hal_send_str("+");
     }
 
     return 0;
@@ -138,6 +139,7 @@ static int test_wrong_pk(void)
             hal_send_str("ERROR Signature did verify correctly under wrong public key!\n");
         }
         hal_send_str("crypto_sign_open DONE.\n");
+        hal_send_str("+");
     }
 
     return 0;

--- a/mupq.py
+++ b/mupq.py
@@ -204,6 +204,8 @@ class BoardTestCase(abc.ABC):
     """
     test_type = 'undefined'
 
+    iterations = 1
+
     def __init__(self, settings, interface):
         self.platform_settings = settings
         self.interface = interface
@@ -219,7 +221,7 @@ class BoardTestCase(abc.ABC):
                                     self.platform_settings.binary_type)
         binary = implementation.get_binary_path(f'{self.test_type}',
                                                 self.platform_settings.binary_type)
-        return self.interface.run(binary)
+        return self.interface.run(binary, self.iterations)
 
     def test_all(self, args=[]):
         implementations = []
@@ -244,6 +246,7 @@ class SimpleTest(BoardTestCase):
     test_type = 'test'
 
     def run_test(self, implementation):
+        self.iterations = 30 if implementation.primitive == "crypto_sign" else 45
         output = super().run_test(implementation).strip()
         if output.count("ERROR") or output.count("OK") != 30:
             self.log.error("Test %s - %s Failed!", implementation, self.test_type)
@@ -285,6 +288,10 @@ class StackBenchmark(BoardTestCase):
 
 class SpeedBenchmark(StackBenchmark):
     test_type = 'speed'
+
+    def __init__(self, *args, **kwargs):
+        super(SpeedBenchmark, self).__init__(*args, **kwargs)
+        self.iterations = self.platform_settings.iterations
 
 class HashingBenchmark(StackBenchmark):
     test_type = 'hashing'

--- a/mupq.py
+++ b/mupq.py
@@ -3,7 +3,9 @@ from collections import defaultdict
 import contextlib
 import re
 import os
+import os.path
 import logging
+import logging.handlers
 import subprocess
 import hashlib
 import time
@@ -27,8 +29,18 @@ class TqdmLoggingHandler(logging.StreamHandler):
         except:
             self.handleError(record)
 
+formater = logging.Formatter("%(asctime)s %(name)s %(levelname)s: %(message)s")
+stream_handler = TqdmLoggingHandler()
+stream_handler.setLevel(logging.WARNING)
+stream_handler.setFormatter(formater)
+LOGFILE = "mupq.log"
+file_handler = logging.handlers.RotatingFileHandler(LOGFILE, backupCount=10)
+file_handler.setLevel(logging.DEBUG)
+file_handler.setFormatter(formater)
+if os.path.isfile(LOGFILE):
+    file_handler.doRollover()
 
-logging.basicConfig(level=logging.WARNING, handlers=[TqdmLoggingHandler()])
+logging.basicConfig(level=logging.DEBUG, handlers=[stream_handler, file_handler], force=True)
 
 class Implementation(object):
     """Contains some properties of a scheme implementation"""

--- a/platforms.py
+++ b/platforms.py
@@ -45,17 +45,22 @@ class Qemu(mupq.Platform):
         ]
         self.log.info(f'Running QEMU: {" ".join(args)}')
         proc = subprocess.Popen(args, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, encoding="ascii")
-        output = ""
-        while "#" not in output:
-            buf = proc.stdout.readline()
-            # print(buf)
-            output += buf
-            if expiterations > 1:
-                if "+" in buf:
-                    pb.update(buf.count("+"))
-                else:
-                    pb.refresh()
-        proc.wait()
+        try:
+            output = ""
+            while "#" not in output:
+                buf = proc.stdout.readline()
+                # print(buf)
+                output += buf
+                if expiterations > 1:
+                    if "+" in buf:
+                        pb.update(buf.count("+"))
+                    else:
+                        pb.refresh()
+            proc.wait()
+        except Exception as e:
+            if proc and proc.poll is not None:
+                proc.kill()
+            raise e
         start = self.start_pat.search(output)
         end = self.end_pat.search(output, start.end())
         if end is None:


### PR DESCRIPTION
This revamps the entire logging of `mupq`. Pretty much kicks out all the logging from the console, except errors and test pass/fail messages. This frees up the clutter and makes space for a progress bar. The bar is based on the `tqdm` package, which also has support for time tracking etc.

For even longer tests, I also added progress tracking for the longer running tests. Especially the `test` and `speed` test can be quite long-running due to their many iterations, so the gui comes with stacked progress bars (one for the schemes, one for the iterations).

Since a full log is still useful, the full log is dumped into a `mupq.log` file, which is rotated ten times so you don't immediately loose previous runs.