### PR TITLE
Update PQClean

### DIFF
--- a/common/compat.h
+++ b/common/compat.h
@@ -1,0 +1,7 @@
+#ifndef COMPAT_H
+#define COMPAT_H
+
+
+#define PQCLEAN_VLA(__t,__x,__s) __t __x[__s]
+
+#endif


### PR DESCRIPTION
This update is mostly brining three changes:
- Update the Kyber and Dilithium implementations to be compatible with the 'standard'-branches of the official repositories 
- Eliminate the code in Kyber (`poly_tomsg`, `poly_compress`, `polyvec_compress`) that results in variable-time division instructions for certain compilers with certain build flags (see https://github.com/PQClean/PQClean/pull/534)
- Update SPHINCS+ to only include the parameters selected by NIST

I have been delaying for quite some time, apologies. 