### PR TITLE
Symlink to missing header used by ClassicMcEliece

### DIFF
--- a/common/crypto_declassify.h
+++ b/common/crypto_declassify.h
@@ -1,0 +1,1 @@
+../pqclean/common/crypto_declassify.h


### PR DESCRIPTION
McEliece uses a `crypto_declassify.h` header. It doesn't do anything platform dependent, so I just symlinked it.