### PR TITLE
Adds Apache-2.0 license in addition to CC0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,5 @@ Provides common files for instances of **mupq**, e.g., for
  - https://github.com/mupq/pqriscv
 
 # License
-Different parts of **mupq** have different licenses. Each subdirectory containing implementations contains a LICENSE file stating under what license that specific implementation is released. The files in common contain licensing information at the top of the file (and are currently either public domain or MIT). All other code in this repository is released under the conditions of [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+Different parts of **mupq** have different licenses. Each subdirectory containing implementations contains a LICENSE file stating under what license that specific implementation is released. The files in common contain licensing information at the top of the file (and are currently either public domain or MIT).
+All other code in this repository is dual-licensed under [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) and under the conditions of [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/common/aes-publicinputs.h
+++ b/common/aes-publicinputs.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #ifndef AES_PUBLICINPUTS_H
 #define AES_PUBLICINPUTS_H
 

--- a/common/aes.h
+++ b/common/aes.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #ifndef AES_H
 #define AES_H
 

--- a/common/compat.h
+++ b/common/compat.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #ifndef COMPAT_H
 #define COMPAT_H
 

--- a/common/crypto_hashblocks_sha512.h
+++ b/common/crypto_hashblocks_sha512.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #ifndef CRYPTO_HASHBLOCKS_SHA512_H
 #define CRYPTO_HASHBLOCKS_SHA512_H
 

--- a/common/fips202.c
+++ b/common/fips202.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 /* Based on the public domain implementation in
  * crypto_hash/keccakc512/simple/ from http://bench.cr.yp.to/supercop.html
  * by Ronny Van Keer

--- a/common/fips202.h
+++ b/common/fips202.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #ifndef FIPS202_H
 #define FIPS202_H
 

--- a/common/hal.h
+++ b/common/hal.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #ifndef HAL_H
 #define HAL_H
 

--- a/common/sendfn.h
+++ b/common/sendfn.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #ifndef SENDFN_H
 #define SENDFN_H
 

--- a/crypto_kem/hashing.c
+++ b/crypto_kem/hashing.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #include "api.h"
 #include "hal.h"
 #include "sendfn.h"

--- a/crypto_kem/speed.c
+++ b/crypto_kem/speed.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #include "api.h"
 #include "hal.h"
 #include "sendfn.h"

--- a/crypto_kem/stack.c
+++ b/crypto_kem/stack.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #include "api.h"
 #include "randombytes.h"
 #include "hal.h"

--- a/crypto_kem/test.c
+++ b/crypto_kem/test.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #include "api.h"
 #include "randombytes.h"
 #include "hal.h"

--- a/crypto_kem/testvectors-host.c
+++ b/crypto_kem/testvectors-host.c
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
+
 /* Deterministic randombytes by Daniel J. Bernstein */
 /* taken from SUPERCOP (https://bench.cr.yp.to)     */
 

--- a/crypto_kem/testvectors.c
+++ b/crypto_kem/testvectors.c
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
+
 /* Deterministic randombytes by Daniel J. Bernstein */
 /* taken from SUPERCOP (https://bench.cr.yp.to)     */
 

--- a/crypto_sign/hashing.c
+++ b/crypto_sign/hashing.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #include "api.h"
 #include "hal.h"
 #include "sendfn.h"

--- a/crypto_sign/speed.c
+++ b/crypto_sign/speed.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #include "api.h"
 #include "hal.h"
 #include "sendfn.h"

--- a/crypto_sign/stack.c
+++ b/crypto_sign/stack.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #include "api.h"
 #include "randombytes.h"
 #include "hal.h"

--- a/crypto_sign/test.c
+++ b/crypto_sign/test.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #include "api.h"
 #include "randombytes.h"
 #include "hal.h"

--- a/crypto_sign/testvectors-host.c
+++ b/crypto_sign/testvectors-host.c
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
+
 /* Deterministic randombytes by Daniel J. Bernstein */
 /* taken from SUPERCOP (https://bench.cr.yp.to)     */
 

--- a/crypto_sign/testvectors.c
+++ b/crypto_sign/testvectors.c
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
+
 /* Deterministic randombytes by Daniel J. Bernstein */
 /* taken from SUPERCOP (https://bench.cr.yp.to)     */
 

--- a/genskiplist.py
+++ b/genskiplist.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 """This script is used to generate the skiplist.py files in pqm{4,3}. It
 takes the output files from the mps2-an386 target, when run via the make
 script, i.e., compile pqm{4,3} with the mps2-an38{6,5} plattform and the

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 ifndef _CONFIG
 _CONFIG :=
 

--- a/mk/host-crypto.mk
+++ b/mk/host-crypto.mk
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 HOST_SYMCRYPTO_SRC = \
 	mupq/common/fips202.c \
 	mupq/common/sp800-185.c \

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 ELFNAME = $*
 
 obj/_ELFNAME_%.o: $(CONFIG)

--- a/mk/schemes.mk
+++ b/mk/schemes.mk
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 ifndef IMPLEMENTATION_PATH
 # If IMPLEMENTATION_PATH isn't defined (usually with the call to make), all
 # default search paths will be searched

--- a/mupq.py
+++ b/mupq.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 import abc
 from collections import defaultdict
 import contextlib

--- a/platforms.py
+++ b/platforms.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 from mupq import mupq
 
 import abc


### PR DESCRIPTION
To enable re-use in https://github.com/pq-code-package/mlkem-c-embedded. This is applied only to the sources of pqm4 itself that are to a vast degree written by the pqm4 maintainers.
The scheme implementations plus symmetric primitives have other licenses.