### PR TITLE
Check if signatures are accepted in benchmarks

### DIFF
--- a/crypto_sign/hashing.c
+++ b/crypto_sign/hashing.c
@@ -36,6 +36,7 @@ int main(void)
   unsigned char pk[MUPQ_CRYPTO_PUBLICKEYBYTES];
   unsigned char sm[MLEN+MUPQ_CRYPTO_BYTES];
   size_t smlen;
+  unsigned int rc;
   unsigned long long t0, t1;
   int i;
 
@@ -65,11 +66,14 @@ int main(void)
     // Verification
     hash_cycles = 0;
     t0 = hal_get_time();
-    MUPQ_crypto_sign_open(sm, &smlen, sm, smlen, pk);
+    rc = MUPQ_crypto_sign_open(sm, &smlen, sm, smlen, pk);
     t1 = hal_get_time();
     printcycles("verify cycles:", t1-t0);
     printcycles("verify hash cycles:", hash_cycles);
 
+    if (rc) {
+      hal_send_str("ERROR Signature did not verify correctly!\n");
+    }
     hal_send_str("+");
   }
 

--- a/crypto_sign/speed.c
+++ b/crypto_sign/speed.c
@@ -35,6 +35,7 @@ int main(void)
   unsigned char pk[MUPQ_CRYPTO_PUBLICKEYBYTES];
   unsigned char sm[MLEN+MUPQ_CRYPTO_BYTES];
   size_t smlen;
+  unsigned int rc;
   unsigned long long t0, t1;
   int i;
 
@@ -59,10 +60,13 @@ int main(void)
 
     // Verification
     t0 = hal_get_time();
-    MUPQ_crypto_sign_open(sm, &smlen, sm, smlen, pk);
+    rc = MUPQ_crypto_sign_open(sm, &smlen, sm, smlen, pk);
     t1 = hal_get_time();
     printcycles("verify cycles:", t1-t0);
 
+    if (rc) {
+      hal_send_str("ERROR Signature did not verify correctly!\n");
+    }
     hal_send_str("+");
   }
   hal_send_str("#");

--- a/crypto_sign/stack.c
+++ b/crypto_sign/stack.c
@@ -63,6 +63,7 @@ static int test_sign(void) {
   stack_verify = hal_checkstack();
 
   if (rc) {
+    hal_send_str("ERROR Signature did not verify correctly!\n");
     return -1;
   } else {
     send_stack_usage("keypair stack usage:", stack_key_gen);


### PR DESCRIPTION
Fixes https://github.com/mupq/mupq/issues/160.

Note that no additional checks are needed in `mupq.py`, since `SpeedBenchmark` and `HashingBenchmark` derive from `StackBenchmark`:

https://github.com/mupq/mupq/blob/21dbaf66627cbb3ac326e4b695a70b13e21d3914/mupq.py#L314
https://github.com/mupq/mupq/blob/21dbaf66627cbb3ac326e4b695a70b13e21d3914/mupq.py#L321

and neither overrides the `run_test` method, which in `StackBenchmark` already checks for errors:

https://github.com/mupq/mupq/blob/21dbaf66627cbb3ac326e4b695a70b13e21d3914/mupq.py#L308